### PR TITLE
secrets tracer malfunction #694

### DIFF
--- a/HSTracker/Logging/Handlers/TagChangeActions.swift
+++ b/HSTracker/Logging/Handlers/TagChangeActions.swift
@@ -114,7 +114,7 @@ struct TagChangeActions {
             } else if entity.isInZone(zone: .play) {
                 game.opponentStolen(entity: entity, cardId: entity.cardId, turn: game.turnNumber())
             }
-        } else if value == game.opponent.id {
+        } else if value == game.opponent.id && prevValue != value {
             if entity.isInZone(zone: .secret) {
                 game.playerStolen(entity: entity, cardId: entity.cardId, turn: game.turnNumber())
                 game.proposeKeyPoint(type: .secretStolen, id: id, player: .player)


### PR DESCRIPTION
I'm actually not sure what's triggering controllerChange, but I figured if something is owned by the opponent and transfers to the opponent, that doesn't need to be stolen?

This fixes the secret stuff not disappearing