### PR TITLE
Move the secret tracker so slightly. Picture attached

### DIFF
--- a/HSTracker/Core/SizeHelper.swift
+++ b/HSTracker/Core/SizeHelper.swift
@@ -240,7 +240,7 @@ struct SizeHelper {
     }
 
     static func secretTrackerFrame() -> NSRect {
-        let frame = NSRect(x: 200, y: hearthstoneWindow.frame.height - 500,
+        let frame = NSRect(x: 200, y: hearthstoneWindow.frame.height - 550,
                            width: trackerWidth, height: 450)
         
         return hearthstoneWindow.relativeFrame(frame)


### PR DESCRIPTION
<img width="1675" alt="screen shot 2017-01-02 at 11 44 57 am" src="https://cloud.githubusercontent.com/assets/1222855/21595303/65177fa0-d0e1-11e6-849c-7a3c05131d31.png">

I'm not sure if this is retina only. Because it was slightly off screen without it.