### PR TITLE
Fixed random tracking problem

### DIFF
--- a/HSTracker.xcodeproj/project.pbxproj
+++ b/HSTracker.xcodeproj/project.pbxproj
@@ -277,6 +277,7 @@
 		64C11831FAF872B46E57E719 /* CardIds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64C117BCDB7C91174D0EAD99 /* CardIds.swift */; };
 		BC2B851E1D749E9800BC812B /* Hearthstonetopdecks.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC2B851D1D749E9800BC812B /* Hearthstonetopdecks.swift */; };
 		BC90FD0B1D97F81B00BAFC0D /* GraveyardCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC90FD0A1D97F81B00BAFC0D /* GraveyardCounter.swift */; };
+		BCA70F2A1E2C16DD00038A6C /* FileUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = BCA70F291E2C16DD00038A6C /* FileUtils.m */; };
 		C92C680E1D1F225F009030DC /* StatsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92C680C1D1F225F009030DC /* StatsTab.swift */; };
 		C92C68121D1F3FC4009030DC /* LadderTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92C68101D1F3FC4009030DC /* LadderTab.swift */; };
 		C92C68181D1F74CE009030DC /* LadderGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92C68171D1F74CE009030DC /* LadderGrid.swift */; };
@@ -722,6 +723,8 @@
 		64C117BCDB7C91174D0EAD99 /* CardIds.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardIds.swift; sourceTree = "<group>"; };
 		BC2B851D1D749E9800BC812B /* Hearthstonetopdecks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Hearthstonetopdecks.swift; sourceTree = "<group>"; };
 		BC90FD0A1D97F81B00BAFC0D /* GraveyardCounter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraveyardCounter.swift; sourceTree = "<group>"; };
+		BCA70F281E2C16DD00038A6C /* FileUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FileUtils.h; sourceTree = "<group>"; };
+		BCA70F291E2C16DD00038A6C /* FileUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FileUtils.m; sourceTree = "<group>"; };
 		C92C680C1D1F225F009030DC /* StatsTab.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StatsTab.swift; path = StatsManager/StatsTab.swift; sourceTree = "<group>"; };
 		C92C68101D1F3FC4009030DC /* LadderTab.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LadderTab.swift; path = StatsManager/LadderTab.swift; sourceTree = "<group>"; };
 		C92C68171D1F74CE009030DC /* LadderGrid.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LadderGrid.swift; path = Statistics/LadderGrid.swift; sourceTree = "<group>"; };
@@ -960,6 +963,8 @@
 				434D1CB01D0C507900222B8E /* ImageCompare.swift */,
 				4359BFA41D5243FD00F61993 /* Automation.swift */,
 				43AFEEEA1E22529C00F6045A /* CollectionManager.swift */,
+				BCA70F281E2C16DD00038A6C /* FileUtils.h */,
+				BCA70F291E2C16DD00038A6C /* FileUtils.m */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -1693,6 +1698,7 @@
 				64C11831FAF872B46E57E719 /* CardIds.swift in Sources */,
 				BC90FD0B1D97F81B00BAFC0D /* GraveyardCounter.swift in Sources */,
 				4323C5F71E1BE28800C97896 /* BrawlInfo.swift in Sources */,
+				BCA70F2A1E2C16DD00038A6C /* FileUtils.m in Sources */,
 				434D1CB11D0C507900222B8E /* ImageCompare.swift in Sources */,
 				435CD9091E1E3AB4000AF3DE /* GameStats.swift in Sources */,
 				435CD90B1E1E4447000AF3DE /* ServerInfo.swift in Sources */,

--- a/HSTracker/HSTracker-Bridging-Header.h
+++ b/HSTracker/HSTracker-Bridging-Header.h
@@ -23,4 +23,6 @@
 #import <HearthMirror/HearthMirror.h>
 #import <HearthMirror/security.h>
 
+#import "FileUtils.h"
+
 #endif /* HSTracker_Bridging_Header_h */

--- a/HSTracker/Logging/Hearthstone.swift
+++ b/HSTracker/Logging/Hearthstone.swift
@@ -20,12 +20,17 @@ enum HearthstoneLogError: Error {
 final class Hearthstone: NSObject {
     let applicationName = "Hearthstone"
 
-    lazy var logReaderManager = LogReaderManager()
+    var logReaderManager: LogReaderManager
 
     var mirror: HearthMirror?
 
     var hearthstoneActive = false
     var queue = DispatchQueue(label: "be.michotte.hstracker.readers", attributes: [])
+    
+    override init() {
+        logReaderManager = LogReaderManager(logPath: Settings.instance.hearthstoneLogPath)
+        super.init()
+    }
 
     static let instance = Hearthstone()
 

--- a/HSTracker/Logging/LogReader.swift
+++ b/HSTracker/Logging/LogReader.swift
@@ -24,13 +24,13 @@ final class LogReader {
 
     private var queue: DispatchQueue?
 
-    init(info: LogReaderInfo) {
+    init(info: LogReaderInfo, logPath: String) {
         self.info = info
 
-        self.path = Hearthstone.instance.logPath + "/Logs/\(info.name).log"
+        self.path = logPath + "/Logs/\(info.name).log"
         Log.info?.message("Init reader for \(info.name) at path \(self.path)")
         if fileManager.fileExists(atPath: self.path)
-            && !Hearthstone.instance.isHearthstoneRunning {
+            && !FileUtils.isFileOpen(byHearthstone: self.path) {
             do {
                 try fileManager.removeItem(atPath: self.path)
             } catch {

--- a/HSTracker/Logging/LogReaderManager.swift
+++ b/HSTracker/Logging/LogReaderManager.swift
@@ -18,17 +18,12 @@ final class LogReaderManager {
     let loadingScreenHandler = LoadingScreenHandler()
     var fullScreenFxHandler = FullScreenFxHandler()
 
-    private let powerLog = LogReader(info: LogReaderInfo(name: .power,
-        startsWithFilters: ["PowerTaskList.DebugPrintPower",
-            "GameState.DebugPrintEntityChoices\\(\\)\\s-\\sid=(\\d) Player=(.+) TaskList=(\\d)"],
-        containsFilters: ["Begin Spectating", "Start Spectator", "End Spectator"]))
-    private let gameStatePowerLogReader = LogReader(info: LogReaderInfo(name: .power,
-        startsWithFilters: ["GameState."], include: false))
-    private let rachelle = LogReader(info: LogReaderInfo(name: .rachelle))
-    private let arena = LogReader(info: LogReaderInfo(name: .arena))
-    private let loadingScreen = LogReader(info: LogReaderInfo(name: .loadingScreen,
-        startsWithFilters: ["LoadingScreen.OnSceneLoaded", "Gameplay"]))
-    private let fullScreenFx = LogReader(info: LogReaderInfo(name: .fullScreenFX))
+    private let powerLog: LogReader
+    private let gameStatePowerLogReader: LogReader
+    private let rachelle: LogReader
+    private let arena: LogReader
+    private let loadingScreen: LogReader
+    private let fullScreenFx: LogReader
 
     private var readers: [LogReader] {
         return [powerLog, rachelle, arena, loadingScreen, fullScreenFx]
@@ -36,6 +31,21 @@ final class LogReaderManager {
 
     var running = false
     var stopped = false
+    
+    init(logPath: String) {
+        powerLog = LogReader(info: LogReaderInfo(name: .power,
+                        startsWithFilters: ["PowerTaskList.DebugPrintPower",
+                            "GameState.DebugPrintEntityChoices\\(\\)\\s-\\sid=(\\d) Player=(.+) TaskList=(\\d)"],
+                        containsFilters: ["Begin Spectating", "Start Spectator", "End Spectator"]), logPath: logPath)
+        
+        gameStatePowerLogReader = LogReader(info: LogReaderInfo(name: .power,
+                                startsWithFilters: ["GameState."], include: false), logPath: logPath)
+        rachelle = LogReader(info: LogReaderInfo(name: .rachelle), logPath: logPath)
+        arena = LogReader(info: LogReaderInfo(name: .arena), logPath: logPath)
+        loadingScreen = LogReader(info: LogReaderInfo(name: .loadingScreen,
+                                startsWithFilters: ["LoadingScreen.OnSceneLoaded", "Gameplay"]), logPath: logPath)
+        fullScreenFx = LogReader(info: LogReaderInfo(name: .fullScreenFX), logPath: logPath)
+    }
 
     func start() {
         guard !running else {

--- a/HSTracker/Utility/FileUtils.h
+++ b/HSTracker/Utility/FileUtils.h
@@ -1,0 +1,15 @@
+//
+//  FileUtils.h
+//  HSTracker
+//
+//  Created by Istvan Fehervari on 15/01/2017.
+//  Copyright © 2017 Benjamin Michotte. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface FileUtils : NSObject
+
++(bool)isFileOpenByHearthstone:(NSString*)filePath;
+
+@end

--- a/HSTracker/Utility/FileUtils.m
+++ b/HSTracker/Utility/FileUtils.m
@@ -1,0 +1,60 @@
+//
+//  FileUtils.m
+//  HSTracker
+//
+//  Created by Istvan Fehervari on 15/01/2017.
+//  Copyright © 2017 Benjamin Michotte. All rights reserved.
+//
+
+#import "FileUtils.h"
+#import <libproc.h>
+#import <AppKit/AppKit.h>
+
+@implementation FileUtils
+
++(bool)isFileOpenByHearthstone:(NSString*)filePath {
+    
+    // get Hearthstone PID
+    NSArray *runningApps = [[NSWorkspace sharedWorkspace] runningApplications];
+    
+    pid_t hsPid = 0;
+    for (NSRunningApplication* nsapp in runningApps) {
+        if ([[nsapp localizedName] isEqualToString:@"Hearthstone"]) {
+            hsPid = [nsapp processIdentifier];
+            break;
+        }
+    }
+    
+    if (hsPid == 0) return NO;
+    
+    int listpidspathResult = 0;
+    listpidspathResult = proc_listpidspath(PROC_ALL_PIDS, 0,
+                                           [filePath cStringUsingEncoding:NSUTF8StringEncoding], PROC_LISTPIDSPATH_EXCLUDE_EVTONLY, nil, 0);
+    
+    if (listpidspathResult <= 1) return NO;
+    
+    // check if really Hearthstone is writing the file and not some other process (unlikely)
+    
+    int pidsSize = (listpidspathResult ? listpidspathResult : 1);
+    pid_t *pids = malloc(pidsSize);
+    
+    listpidspathResult = proc_listpidspath(PROC_ALL_PIDS, 0,
+                                           [filePath cStringUsingEncoding:NSUTF8StringEncoding], PROC_LISTPIDSPATH_EXCLUDE_EVTONLY, pids,
+                                           pidsSize);
+    
+    NSUInteger pidsCount = (listpidspathResult / sizeof(*pids));
+    NSMutableSet* result = [NSMutableSet set];
+    
+    for (int i = 0; i < pidsCount; i++) {
+        [result addObject: [NSNumber numberWithInt: pids[i]]];
+        if (hsPid == pids[i]) {
+            free(pids);
+            return YES;
+        }
+    }
+    
+    free(pids);
+    return NO;
+}
+
+@end


### PR DESCRIPTION
Initial logfile offset was not calculated properly as HSTracker was unable to erase the log files when needed.

The root cause of the issue was that
1, LogReader was checking for a running game instance, but it was always true as this check was run after the game was launched. This was probably the result of the circular dependency between the Hearthstone singleton and a LogReader instance. This PR unwinds this dependency.

2, Unlike under Windows, it is possible to delete log files while the game is actively using them. A proper check has been implemented to be sure if the logs are free for deletion.