### PR TITLE
[FIX] Removed default all rows highlight.

### DIFF
--- a/HSTracker/UIs/DeckManager/DeckManager.swift
+++ b/HSTracker/UIs/DeckManager/DeckManager.swift
@@ -548,7 +548,7 @@ extension DeckManager: NSTableViewDelegate {
                     !deck.standardViable() && !deck.isArena ?
                     NSImage(named: "Mode_Wild") : nil
                 cell.color = ClassColor.color(playerClass: deck.playerClass)
-                cell.selected = tableView.selectedRow == -1 || tableView.selectedRow == row
+                cell.selected = tableView.selectedRow == row
                 
                 let record = StatsHelper.getDeckRecord(deck: deck, mode: .all)
                 switch sortCriteria {


### PR DESCRIPTION
Hey, 
I thought it was pretty annoying that all rows in the DeckManager are highlighted as a default, so
here is a pretty sophisticated change to solve that...
