### PR TITLE
[FIX] Copy gameMode and opponentHero to fix stats.

### DIFF
--- a/HSTracker/Database/Models/GameStats.swift
+++ b/HSTracker/Database/Models/GameStats.swift
@@ -62,10 +62,12 @@ class InternalGameStats {
         gameStats.hearthstoneBuild.value = hearthstoneBuild
         gameStats.playerCardbackId = playerCardbackId
         gameStats.opponentCardbackId = opponentCardbackId
+        gameStats.opponentHero = opponentHero
         gameStats.friendlyPlayerId = friendlyPlayerId
         gameStats.scenarioId = scenarioId
         gameStats.serverInfo = serverInfo
         gameStats.season = season
+        gameStats.gameMode = gameMode
         gameStats.gameType = gameType
         gameStats.hsDeckId.value = hsDeckId
         gameStats.brawlSeasonId = brawlSeasonId


### PR DESCRIPTION
So apparently the stats were not displaying correctly, because there was no information
on the gameMode and opponentHero passed. I changed that, although I am not sure if 
this is the way it is supposed to work. Whatever, here is a PR fixing the stats screen for
me.