### PR TITLE
Bug Fix: In deck builder, legendaries are darkened after adding one copy to a non-arena deck

### DIFF
--- a/HSTracker/UIs/Cards/CardBar.swift
+++ b/HSTracker/UIs/Cards/CardBar.swift
@@ -295,7 +295,7 @@ class CardBar: NSView, CardBarTheme {
         addCardName()
         if let card = card, playerType != .hero {
             if let isArena = isArena,
-                playerType == .editDeck && !isArena && card.count >= 2 {
+                playerType == .editDeck && !isArena && (card.count >= 2 || (card.count == 1 && card.rarity == .legendary)) {
                 addDarken()
             } else if (card.count <= 0 || card.jousted)
                 && playerType != .cardList && playerType != .editDeck {


### PR DESCRIPTION
<img width="1073" alt="screen shot 2017-04-29 at 10 29 55 pm" src="https://cloud.githubusercontent.com/assets/4468901/25561458/5d8a6666-2d3a-11e7-9ef6-86849b003a6b.png">

As seen above, Rares are darkened after two copies are added.
Legendaries should darken after one copy is added.