### PR TITLE
Fix Danger check for Info.plist

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -29,9 +29,9 @@ if has_app_changes && !has_test_changes && git.lines_of_code > 10
 end
 
 # Info.plist file shouldn't change often. Leave warning if it changes.
-is_plist_change = git.modified_files.sort == ["ProjectName/Info.plist"].sort
+is_plist_change = !git.modified_files.grep("ProjectName/Info.plist").empty?
 
-if !is_plist_change
+if is_plist_change
   warn "Plist changed, don't forget to localize your plist values"
 end
 


### PR DESCRIPTION
Current Dangerfile fail to detect if changes are made for `Info.plist` file. 
e.g. #967 includes no changes to `Info.plist` but Danger stills showed warning.