### PR TITLE
Use correct fastlane lane for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ before_install:
   - ./scripts/cards_download.sh
 
 script:
-  - bundle exec fastlane scan
+  - bundle exec fastlane ci
 


### PR DESCRIPTION
#951 introduced a new CI lane which prepares CI environment, build Carthage packages, and finally Xcode test. However, it wasn't really used after all and thereafter breaks recent CI builds.