### PR TITLE
Update swiftlint deprecated rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,7 +10,7 @@ disabled_rules:
   - file_length
   - type_body_length
   - todo
-  - variable_name
+  - identifier_name
   - function_parameter_count
   - trailing_newline
   - trailing_whitespace


### PR DESCRIPTION
Just saw this warning:
> 'variable_name' rule has been renamed to 'identifier_name' and will be completely removed in a future release.