### PR TITLE
Make FloatingCard text readable for OSX dark mode

### DIFF
--- a/HSTracker/UIs/Trackers/FloatingCard.swift
+++ b/HSTracker/UIs/Trackers/FloatingCard.swift
@@ -34,16 +34,16 @@ class FloatingCard: OverWindowController {
     
     let attributes: TextAttributes = {
         $0.font(NSFont(name: "Belwe Bd BT", size: 13))
-            .foregroundColor(.black)
-            .strokeColor(.black)
+            .foregroundColor(.textColor)
+            .strokeColor(.textColor)
             .alignment(.center)
         return $0
     }(TextAttributes())
 
     let titleAttributes: TextAttributes = {
         $0.font(NSFont(name: "Belwe Bd BT", size: 16))
-            .foregroundColor(.black)
-            .strokeColor(.black)
+            .foregroundColor(.textColor)
+            .strokeColor(.textColor)
             .alignment(.center)
         return $0
     }(TextAttributes())


### PR DESCRIPTION
Set FloatingCard's text color using the `textColor` variable instead of hardcoding it to `black` so the text shows up on both light and dark modes' backgrounds.

Before:
<img width="187" alt="screen shot 2018-12-23 at 8 31 11 pm" src="https://user-images.githubusercontent.com/3230904/50389019-1ecb4100-06f2-11e9-8b46-921cb971ac6b.png">

After:
<img width="175" alt="screen shot 2018-12-23 at 8 35 23 pm" src="https://user-images.githubusercontent.com/3230904/50389040-533efd00-06f2-11e9-9c03-8084db7b0061.png">

<img width="167" alt="screen shot 2018-12-23 at 8 33 39 pm" src="https://user-images.githubusercontent.com/3230904/50389023-2ab70300-06f2-11e9-8c6b-84d95f36b37b.png">
