### PR TITLE
Optimize the Chinese font displaying

### DIFF
--- a/HSTracker/Core/Settings.swift
+++ b/HSTracker/Core/Settings.swift
@@ -39,11 +39,11 @@ final class Settings {
         }
         return nil
     }
-	
-	static var showMemoryReadingWarning: Bool {
-		set { set(name: Settings.show_memory_reading_warning, value: newValue) }
-		get { return get(name: Settings.show_memory_reading_warning) as? Bool ?? true }
-	}
+    
+    static var showMemoryReadingWarning: Bool {
+        set { set(name: Settings.show_memory_reading_warning, value: newValue) }
+        get { return get(name: Settings.show_memory_reading_warning) as? Bool ?? true }
+    }
     static var canJoinFullscreen: Bool {
         set { set(name: Settings.can_join_fullscreen, value: newValue) }
         get { return get(name: Settings.can_join_fullscreen) as? Bool ?? true }
@@ -493,6 +493,12 @@ final class Settings {
         guard let language = hearthstoneLanguage else { return false }
 
         return language == .ruRU
+    }
+
+    static var isSimplifiedChinese: Bool {
+        guard let language = hearthstoneLanguage else { return false }
+
+        return language == .zhCN
     }
 
     static var isAsianLanguage: Bool {

--- a/HSTracker/UIs/Cards/CardBar.swift
+++ b/HSTracker/UIs/Cards/CardBar.swift
@@ -127,7 +127,9 @@ class CardBar: NSView, CardBarTheme {
         return "ChunkFive"
     }
     var textFont: String {
-        if Settings.isAsianLanguage {
+        if Settings.isSimplifiedChinese {
+            return "AR LisuGB Medium"
+        } else if Settings.isAsianLanguage {
             return "NanumGothic"
         } else if Settings.isCyrillicLanguage {
             return "BenguiatBold"

--- a/HSTracker/UIs/Cards/ClassicBar.swift
+++ b/HSTracker/UIs/Cards/ClassicBar.swift
@@ -15,7 +15,9 @@ class ClassicBar: CardBar {
     private let _costRect = NSRect(x: 1, y: -13, width: 34, height: 37)
 
     override var textFont: String {
-        if Settings.isAsianLanguage {
+        if Settings.isSimplifiedChinese {
+            return "AR LisuGB Medium"
+        } else if Settings.isAsianLanguage {
             return "NanumGothic"
         } else if Settings.isCyrillicLanguage {
             return "Benguiat Rus"


### PR DESCRIPTION
When the user sets the language to Chinese (zh-Hans), the official font of Heatrhstone is called `JingDianLiBianJian`. But currently HSTracker is using font `NanumGothic`, and it looks strange:
![2019-03-02 9 40 00](https://user-images.githubusercontent.com/16272760/53675257-a6739400-3ccf-11e9-9d6b-5b335841abb9.png)
This pull request changes the font of language zh-Hans. The new behavior:
![2019-03-02 9 40 45](https://user-images.githubusercontent.com/16272760/53675265-c440f900-3ccf-11e9-857e-5b311f3d2ae7.png)
![2019-03-02 2 06 51](https://user-images.githubusercontent.com/16272760/53675271-cefb8e00-3ccf-11e9-8937-a67a262b8db8.png)
