### PR TITLE
update nokogiri as 1.8.4 had a security issue (https://nvd.nist.gov/v…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,7 @@ GEM
     multipart-post (2.0.0)
     nanaimo (0.2.6)
     naturally (2.2.0)
-    nokogiri (1.8.4)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     os (1.0.0)
     plist (3.5.0)


### PR DESCRIPTION
…uln/detail/CVE-2018-14404)

It shouldn't be a real problem since this is only used in fastlance but better safe than sorry