### PR TITLE
Fix replay url domain

### DIFF
--- a/HSTracker/HSReplay/HSReplayManager.swift
+++ b/HSTracker/HSReplay/HSReplayManager.swift
@@ -12,7 +12,7 @@ import AppKit
 class HSReplayManager {
 
     class func showReplay(replayId: String) {
-        let url = URL(string: "\(HSReplay.baseUrl)/uploads/upload/\(replayId)"
+        let url = URL(string: "\(HSReplay.hsreplayUrl)/uploads/upload/\(replayId)"
             + "?utm_source=hstracker&utm_medium=client&utm_campaign=replay")
         NSWorkspace.shared.open(url!)
     }


### PR DESCRIPTION
This commit changes the replay URL domain from api.hsreplay.net to hsreplay.net.