### PR TITLE
Fix Augmented Elekk bomb tracking(#1050)

### DIFF
--- a/HSTracker/Hearthstone/Secrets/SecretsManager.swift
+++ b/HSTracker/Hearthstone/Secrets/SecretsManager.swift
@@ -351,28 +351,31 @@ class SecretsManager {
         var exclude: [String] = []
         
         if freeSpaceOnBoard {
-            if let opponent = game.opponentEntity, opponent.has(tag: .num_cards_played_this_turn) &&
-                (opponent[.num_cards_played_this_turn] >= 3) {
+            if let player = game.playerEntity, player.has(tag: .num_cards_played_this_turn) &&
+                (player[.num_cards_played_this_turn] >= 3) {
                     exclude.append(CardIds.Secrets.Hunter.RatTrap)
             }
         }
         
         if freeSpaceInHand {
-            if let opponent = game.opponentEntity, opponent.has(tag: .num_cards_played_this_turn) &&
-                (opponent[.num_cards_played_this_turn] >= 2) {
+            if let player = game.playerEntity, player.has(tag: .num_cards_played_this_turn) &&
+                (player[.num_cards_played_this_turn] >= 3) {
                 exclude.append(CardIds.Secrets.Paladin.HiddenWisdom)
             }
         }
         
         if entity.isSpell {
             exclude.append(CardIds.Secrets.Mage.Counterspell)
-            exclude.append(CardIds.Secrets.Paladin.NeverSurrender)
 
-            if game.opponentHandCount < 10 {
+            if game.opponentMinionCount > 0 {
+                exclude.append(CardIds.Secrets.Paladin.NeverSurrender)
+            }
+
+            if freeSpaceInHand {
                 exclude.append(CardIds.Secrets.Mage.ManaBind)
             }
 
-            if game.opponentMinionCount < 7 {
+            if freeSpaceOnBoard {
                 // CARD_TARGET is set after ZONE, wait for 50ms gametime before checking
                 do {
                     try await {

--- a/HSTracker/Logging/CardIds/Neutral.swift
+++ b/HSTracker/Logging/CardIds/Neutral.swift
@@ -563,6 +563,7 @@ extension CardIds.Collectible {
         static let SparkEngine: String = "BOT_538"
         static let SeaforiumBomber: String = "BOT_511"
         static let SparkDrill: String = "BOT_102"
+        static let AugmentedElekk: String = "BOT_559"
     }
 }
 

--- a/HSTracker/Logging/CardIds/Warrior.swift
+++ b/HSTracker/Logging/CardIds/Warrior.swift
@@ -122,6 +122,8 @@ extension CardIds.Collectible {
         static let KingMosh: String = "UNG_933"
         static let FirePlumesHeart: String = "UNG_934"
         static let DirehornHatchling: String = "UNG_957"
+        static let ClockworkGoblin: String = "DAL_060"
+        static let Wrenchcalibur: String = "DAL_063"
     }
 }
 

--- a/HSTracker/Logging/Parsers/PowerGameStateParser.swift
+++ b/HSTracker/Logging/Parsers/PowerGameStateParser.swift
@@ -359,8 +359,8 @@ class PowerGameStateParser: LogEventParser {
                 type = matches[0].value
             }
             
-            if matches.count > 2 {
-                cardId = matches[2].value
+            if matches.count > 3 {
+                cardId = matches[3].value
             }
             
             blockStart(type: type, cardId: cardId)
@@ -382,6 +382,13 @@ class PowerGameStateParser: LogEventParser {
 
                 if actionStartingCardId.isBlank {
                     return
+                }
+                
+                if type == "TRIGGER" && actionStartingCardId == CardIds.Collectible.Neutral.AugmentedElekk {
+                    if currentBlock?.parent != nil {
+                        actionStartingCardId = currentBlock?.parent?.cardId
+                        type = currentBlock?.parent?.type
+                    }
                 }
 
                 if type == "TRIGGER" {
@@ -433,6 +440,9 @@ class PowerGameStateParser: LogEventParser {
                         case CardIds.Collectible.Neutral.SparkDrill:
                             addKnownCardId(eventHandler: eventHandler,
                                            cardId: CardIds.NonCollectible.Neutral.SparkDrill_SparkToken, count: 2)
+                        case CardIds.Collectible.Warrior.Wrenchcalibur:
+                            addKnownCardId(eventHandler: eventHandler,
+                                           cardId: CardIds.NonCollectible.Neutral.SeaforiumBomber_BombToken)
                         default: break
                         }
                     }
@@ -551,6 +561,9 @@ class PowerGameStateParser: LogEventParser {
                             addKnownCardId(eventHandler: eventHandler,
                                            cardId: CardIds.NonCollectible.Priest.ExtraArms_MoreArmsToken)
                         case CardIds.Collectible.Neutral.SeaforiumBomber:
+                            addKnownCardId(eventHandler: eventHandler,
+                                           cardId: CardIds.NonCollectible.Neutral.SeaforiumBomber_BombToken)
+                        case CardIds.Collectible.Warrior.ClockworkGoblin:
                             addKnownCardId(eventHandler: eventHandler,
                                            cardId: CardIds.NonCollectible.Neutral.SeaforiumBomber_BombToken)
                         default:


### PR DESCRIPTION
Additional bombs triggered by Augmented Elekk are now tracked correctly.

Also, I notice that Block.cardId is assigned with a value of the format like "cardId=DAL_060" when a new Block is created. I suppose it makes more sense if it is assigned with a value like "DAL_060" rather than "cardId=DAL_060", based on the whole code logic. Let me know if I understand it wrong.