### PR TITLE
Fix secret helper causing lag(#972, #994)

### DIFF
--- a/HSTrackerTests/SecretTests.swift
+++ b/HSTrackerTests/SecretTests.swift
@@ -302,6 +302,8 @@ class SecretTests: HSTrackerTests {
     func testSingleSecret_OneMinionDied() {
         opponentMinion2[.zone] = Zone.play.rawValue
         game.opponentMinionDeath(entity: opponentMinion1, turn: 2)
+        
+        wait(for: game.secretsManager?.avengeDelay ?? 50 + 2)
 
         verifySecrets(secretIndex: 0, allSecrets: CardIds.Secrets.Hunter.All)
         verifySecrets(secretIndex: 1, allSecrets: CardIds.Secrets.Mage.All,


### PR DESCRIPTION
Fix the issue(#972 and #994) of secret helper causing HSTracker lag.

To reproduce the problem:
1. The opponent has at least one active secret and at least two minions on board
2. The player kills one of the opponent's minions
3. HSTracker will freeze completely for around 50 seconds