### PR TITLE
Fix secret handling when minion dies

### DIFF
--- a/HSTracker/Hearthstone/Secrets/SecretsManager.swift
+++ b/HSTracker/Hearthstone/Secrets/SecretsManager.swift
@@ -144,7 +144,7 @@ class SecretsManager {
             cards = cards.filter { !CardIds.Secrets.arenaOnly.contains($0.id) }
         }
 
-        return cards.filter { $0.count > 0 }
+        return cards.filter { $0.count > 0 }.sortCardList()
     }
 
     func handleAttack(attacker: Entity, defender: Entity, fastOnly: Bool = false) {

--- a/HSTracker/Logging/Enums/GameTag.swift
+++ b/HSTracker/Logging/Enums/GameTag.swift
@@ -340,6 +340,7 @@ enum GameTag: Int, WrappableEnum, CaseIterable {
     overridecardtextbuilder = 782,
     hidden_choice = 813,
     zombeast = 823,
+    modular = 849,
     whizbang_deck_id = 1048
 
     init?(rawString: String) {

--- a/HSTracker/Logging/Game.swift
+++ b/HSTracker/Logging/Game.swift
@@ -1214,6 +1214,7 @@ class Game: NSObject, PowerEventHandler {
 
         if player == .player {
             handleThaurissanCostReduction()
+            secretsManager?.handleTurnStart()
         }
 
         if turnQueue.count > 0 {
@@ -1435,8 +1436,11 @@ class Game: NSObject, PowerEventHandler {
         updateTrackers()
     }
 
-    func playerPlayToGraveyard(entity: Entity, cardId: String?, turn: Int) {
+    func playerPlayToGraveyard(entity: Entity, cardId: String?, turn: Int, playersTurn: Bool) {
         player.playToGraveyard(entity: entity, cardId: cardId, turn: turn)
+        if playersTurn && entity.isMinion {
+            playerMinionDeath(entity: entity)
+        }
         updateTrackers()
     }
 
@@ -1711,12 +1715,16 @@ class Game: NSObject, PowerEventHandler {
         }
     }
 
-    func playerMinionPlayed() {
-        secretsManager?.handleMinionPlayed()
+    func playerMinionPlayed(entity: Entity) {
+        secretsManager?.handleMinionPlayed(entity: entity)
+    }
+    
+    func playerMinionDeath(entity: Entity) {
+        secretsManager?.handlePlayerMinionDeath(entity: entity)
     }
 
     func opponentMinionDeath(entity: Entity, turn: Int) {
-        secretsManager?.handleMinionDeath(entity: entity)
+        secretsManager?.handleOpponentMinionDeath(entity: entity)
     }
 
     func opponentDamage(entity: Entity) {

--- a/HSTracker/Logging/Handlers/LogEventHandlers.swift
+++ b/HSTracker/Logging/Handlers/LogEventHandlers.swift
@@ -92,7 +92,9 @@ protocol PowerEventHandler: class {
 	
 	var playerMinionCount: Int { get }
 	
-	func playerMinionPlayed()
+    func playerMinionPlayed(entity: Entity)
+    
+    func playerMinionDeath(entity: Entity)
 	
 	func opponentDamage(entity: Entity)
     
@@ -118,7 +120,7 @@ protocol PowerEventHandler: class {
 	
 	func playerDeckToPlay(entity: Entity, cardId: String?, turn: Int)
 	
-	func playerPlayToGraveyard(entity: Entity, cardId: String?, turn: Int)
+    func playerPlayToGraveyard(entity: Entity, cardId: String?, turn: Int, playersTurn: Bool)
 	
 	func playerJoust(entity: Entity, cardId: String?, turn: Int)
 	

--- a/HSTracker/Logging/Parsers/TagChangeActions.swift
+++ b/HSTracker/Logging/Parsers/TagChangeActions.swift
@@ -83,7 +83,11 @@ struct TagChangeActions {
         guard let playerEntity = eventHandler.playerEntity else { return }
         
         if playerEntity.isCurrentPlayer {
-            eventHandler.playerMinionPlayed()
+            if let entity = eventHandler.entities[value] {
+                if entity.isMinion {
+                    eventHandler.playerMinionPlayed(entity: entity)
+                }
+            }
         }
     }
 
@@ -422,13 +426,11 @@ struct TagChangeActions {
             
         case .graveyard:
             if controller == eventHandler.player.id {
-                eventHandler.playerPlayToGraveyard(entity: entity, cardId: cardId, turn: eventHandler.turnNumber())
+                eventHandler.playerPlayToGraveyard(entity: entity, cardId: cardId, turn: eventHandler.turnNumber(), playersTurn: eventHandler.playerEntity?.isCurrentPlayer ?? false)
             } else if controller == eventHandler.opponent.id {
-                if let playerEntity = eventHandler.playerEntity {
-                    eventHandler.opponentPlayToGraveyard(entity: entity, cardId: cardId,
-                                                 turn: eventHandler.turnNumber(),
-                                                 playersTurn: playerEntity.isCurrentPlayer)
-                }
+                eventHandler.opponentPlayToGraveyard(entity: entity, cardId: cardId,
+                                                     turn: eventHandler.turnNumber(),
+                                                     playersTurn: eventHandler.playerEntity?.isCurrentPlayer ?? false)
             }
             
         case .removedfromgame, .setaside:

--- a/HSTracker/Logging/Parsers/TagChangeActions.swift
+++ b/HSTracker/Logging/Parsers/TagChangeActions.swift
@@ -20,10 +20,6 @@ struct TagChangeActions {
         case .attacking: return { self.attackingChange(eventHandler: eventHandler, id: id, value: value) }
         case .proposed_defender: return { self.proposedDefenderChange(eventHandler: eventHandler, value: value) }
         case .proposed_attacker: return { self.proposedAttackerChange(eventHandler: eventHandler, value: value) }
-        case .num_minions_played_this_turn:
-            return {
-                self.numMinionsPlayedThisTurnChange(eventHandler: eventHandler, value: value)
-            }
         case .predamage: return { self.predamageChange(eventHandler: eventHandler, id: id, value: value) }
         case .num_turns_in_play: return { self.numTurnsInPlayChange(eventHandler: eventHandler, id: id, value: value) }
         case .num_attacks_this_turn: return { self.numAttacksThisTurnChange(eventHandler: eventHandler, id: id, value: value) }
@@ -58,6 +54,25 @@ struct TagChangeActions {
 
     private func lastCardPlayedChange(eventHandler: PowerEventHandler, value: Int) {
         eventHandler.lastCardPlayed = value
+        guard let playerEntity = eventHandler.playerEntity else { return }
+        guard playerEntity.isCurrentPlayer else { return }
+        
+        if let entity = eventHandler.entities[value] {
+            if !entity.isMinion {
+                return
+            }
+            
+            // check if it is a magnet buff, rather than a minion
+            if entity.has(tag: GameTag.modular) {
+                let pos = entity.tags[GameTag.zone_position]!
+                let neighbor = eventHandler.player.board.first(where: { $0.tags[GameTag.zone_position] == pos + 1 })
+                if neighbor?.card.race == Race.mechanical {
+                    return
+                }
+            }
+            
+            eventHandler.playerMinionPlayed(entity: entity)
+        }
     }
 
     private func defendingChange(eventHandler: PowerEventHandler, id: Int, value: Int) {
@@ -76,19 +91,6 @@ struct TagChangeActions {
 
     private func proposedAttackerChange(eventHandler: PowerEventHandler, value: Int) {
         eventHandler.proposedAttackerEntityId = value
-    }
-
-    private func numMinionsPlayedThisTurnChange(eventHandler: PowerEventHandler, value: Int) {
-        guard value > 0 else { return }
-        guard let playerEntity = eventHandler.playerEntity else { return }
-        
-        if playerEntity.isCurrentPlayer {
-            if let entity = eventHandler.entities[value] {
-                if entity.isMinion {
-                    eventHandler.playerMinionPlayed(entity: entity)
-                }
-            }
-        }
     }
 
     private func predamageChange(eventHandler: PowerEventHandler, id: Int, value: Int) {

--- a/HSTracker/UIs/Trackers/TimerHud.swift
+++ b/HSTracker/UIs/Trackers/TimerHud.swift
@@ -42,6 +42,10 @@ class TimerHud: OverWindowController {
     }
  
     func tick(seconds: Int, playerSeconds: Int, opponentSeconds: Int) {
+        // TODO: turnLabel is nil when running unit tests, which causes crash
+        // a workaround of avoiding crash when running unit tests
+        guard turnLabel != nil else { return }
+        
         guard Settings.showTimer else {
             turnLabel.attributedStringValue = NSAttributedString(string: "")
             playerLabel.attributedStringValue = NSAttributedString(string: "")

--- a/HSTracker/UIs/Trackers/TimerHud.xib
+++ b/HSTracker/UIs/Trackers/TimerHud.xib
@@ -1,7 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="TimerHud" customModule="HSTracker" customModuleProvider="target">
@@ -14,7 +16,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="TimerHud" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" hasShadow="NO" oneShot="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="QvC-M9-y7g" customClass="NSPanel">
+        <window title="TimerHud" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" hasShadow="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="QvC-M9-y7g" customClass="NSPanel">
             <windowStyleMask key="styleMask" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="160" height="87"/>
@@ -25,24 +27,27 @@
                 <subviews>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MfL-6Z-JKo">
                         <rect key="frame" x="18" y="60" width="120" height="27"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="0:00" id="835-KJ-Ve5">
-                            <font key="font" size="18" name="BelweBT-Bold"/>
+                            <font key="font" metaFont="system" size="18"/>
                             <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="DQK-KE-MJC">
                         <rect key="frame" x="18" y="30" width="120" height="38"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="0:00" id="fko-xe-qal">
-                            <font key="font" size="26" name="BelweBT-Bold"/>
+                            <font key="font" metaFont="system" size="26"/>
                             <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="M29-aV-iwd">
                         <rect key="frame" x="18" y="9" width="120" height="27"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="0:00" id="i7C-Zb-Bu5">
-                            <font key="font" size="18" name="BelweBT-Bold"/>
+                            <font key="font" metaFont="system" size="18"/>
                             <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>

--- a/HSTracker/UIs/Trackers/TimerHud.xib
+++ b/HSTracker/UIs/Trackers/TimerHud.xib
@@ -1,9 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
-        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="TimerHud" customModule="HSTracker" customModuleProvider="target">
@@ -16,7 +14,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="TimerHud" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" hasShadow="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="QvC-M9-y7g" customClass="NSPanel">
+        <window title="TimerHud" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" hasShadow="NO" oneShot="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="QvC-M9-y7g" customClass="NSPanel">
             <windowStyleMask key="styleMask" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="160" height="87"/>
@@ -27,27 +25,24 @@
                 <subviews>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MfL-6Z-JKo">
                         <rect key="frame" x="18" y="60" width="120" height="27"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="0:00" id="835-KJ-Ve5">
-                            <font key="font" metaFont="system" size="18"/>
+                            <font key="font" size="18" name="BelweBT-Bold"/>
                             <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="DQK-KE-MJC">
                         <rect key="frame" x="18" y="30" width="120" height="38"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="0:00" id="fko-xe-qal">
-                            <font key="font" metaFont="system" size="26"/>
+                            <font key="font" size="26" name="BelweBT-Bold"/>
                             <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="M29-aV-iwd">
                         <rect key="frame" x="18" y="9" width="120" height="27"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="0:00" id="i7C-Zb-Bu5">
-                            <font key="font" metaFont="system" size="18"/>
+                            <font key="font" size="18" name="BelweBT-Bold"/>
                             <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>


### PR DESCRIPTION
1. Now when the last played minion died after explosive trap or snipe, other secrets still display
2. Add unit tests for that
3. Keep secrets sorted, to prevent them from always changing positions even no secret is triggered or faded out