### PR TITLE
Fix cards tracking for Spirit of the Dead

### DIFF
--- a/HSTracker/Logging/CardIds/Priest.swift
+++ b/HSTracker/Logging/CardIds/Priest.swift
@@ -125,6 +125,7 @@ extension CardIds.Collectible {
         static let GildedGargoyle: String = "LOOT_534"
         static let Chameleos: String = "GIL_142"
         static let ExtraArms: String = "BOT_219"
+        static let SpiritOfTheDead = "TRL_502"
     }
 }
 

--- a/HSTracker/Logging/Parsers/PowerGameStateParser.swift
+++ b/HSTracker/Logging/Parsers/PowerGameStateParser.swift
@@ -14,7 +14,7 @@ import RegexUtil
 class PowerGameStateParser: LogEventParser {
 
     let BlockStartRegex = RegexPattern(stringLiteral: ".*BLOCK_START.*BlockType=(POWER|TRIGGER)"
-        + ".*id=(\\d*).*(cardId=(\\w*)).*Target=(.+).*SubOption=(.+)")
+        + ".*id=(\\d*).*(cardId=(\\w*)).*player=(\\d*).*Target=(.+).*SubOption=(.+)")
     let CardIdRegex: RegexPattern = "cardId=(\\w+)"
     let CreationRegex: RegexPattern = "FULL_ENTITY - Updating.*id=(\\d+).*zone=(\\w+).*CardID=(\\w*)"
     let CreationTagRegex: RegexPattern = "tag=(\\w+) value=(\\w+)"
@@ -354,6 +354,7 @@ class PowerGameStateParser: LogEventParser {
             
             var type: String?
             var cardId: String?
+            var correspondPlayer: Int?
             let matches = logLine.line.matches(BlockStartRegex)
             if matches.count > 0 {
                 type = matches[0].value
@@ -361,6 +362,10 @@ class PowerGameStateParser: LogEventParser {
             
             if matches.count > 3 {
                 cardId = matches[3].value
+            }
+            
+            if matches.count > 4 {
+                correspondPlayer = Int(matches[4].value)!
             }
             
             blockStart(type: type, cardId: cardId)
@@ -443,6 +448,12 @@ class PowerGameStateParser: LogEventParser {
                         case CardIds.Collectible.Warrior.Wrenchcalibur:
                             addKnownCardId(eventHandler: eventHandler,
                                            cardId: CardIds.NonCollectible.Neutral.SeaforiumBomber_BombToken)
+                        case CardIds.Collectible.Priest.SpiritOfTheDead:
+                            if correspondPlayer == eventHandler.player.id {
+                                addKnownCardId(eventHandler: eventHandler, cardId: eventHandler.player.lastDiedMinionCardId)
+                            } else if correspondPlayer == eventHandler.opponent.id {
+                                addKnownCardId(eventHandler: eventHandler, cardId: eventHandler.opponent.lastDiedMinionCardId)
+                            }
                         default: break
                         }
                     }

--- a/HSTracker/Logging/Player.swift
+++ b/HSTracker/Logging/Player.swift
@@ -90,6 +90,7 @@ final class Player {
     var goingFirst = false
     var fatigue = 0
     var heroPowerCount = 0
+    var lastDiedMinionCardId: String?
     fileprivate(set) var spellsPlayedCount = 0
     fileprivate(set) var deathrattlesPlayedCount = 0
 	private unowned(unsafe) let game: Game
@@ -574,6 +575,11 @@ final class Player {
         if entity.isMinion && entity.has(tag: .deathrattle) {
             deathrattlesPlayedCount += 1
         }
+        
+        if entity.isMinion {
+            lastDiedMinionCardId = cardId
+        }
+        
         if Settings.fullGameLog {
             logger.info("\(debugName) \(#function) \(entity)")
         }


### PR DESCRIPTION
Trackers are now able to track those card copies generated by 'Spirit of the Dead' correctly, for both the player and the opponent.