### PR TITLE
Fix secret helper

### DIFF
--- a/HSTracker/Hearthstone/Secrets/SecretsManager.swift
+++ b/HSTracker/Hearthstone/Secrets/SecretsManager.swift
@@ -408,39 +408,44 @@ class SecretsManager {
             }
         }
         
-        if entity.isSpell {
-            exclude.append(CardIds.Secrets.Mage.Counterspell)
-
+        if entity.isMinion && game.playerMinionCount > 3 {
+            exclude.append(CardIds.Secrets.Paladin.SacredTrial)
+        }
+        self.exclude(cardIds: exclude)
+    }
+    
+    // this method is called when a spell is moved from play to graveyard
+    func handleSpellCasted(entity: Entity) {
+        guard handleAction && entity.isSpell else { return }
+        
+        var exclude: [String] = []
+        
+        exclude.append(CardIds.Secrets.Mage.Counterspell)
+        
+        // the spell is not countered by Counter Spell
+        if !entity.has(tag: GameTag.cant_play) {
             if game.opponentMinionCount > 0 {
                 exclude.append(CardIds.Secrets.Paladin.NeverSurrender)
             }
-            if game.playerMinionCount > 0 {
+            
+            if game.isPlayerMinionInPlay {
                 exclude.append(CardIds.Secrets.Hunter.PressurePlate)
             }
-
+            
             if freeSpaceInHand {
                 exclude.append(CardIds.Secrets.Mage.ManaBind)
             }
-
+            
             if freeSpaceOnBoard {
-                // CARD_TARGET is set after ZONE, wait for 50ms gametime before checking
-                do {
-                    try await {
-                        Thread.sleep(forTimeInterval: 0.2)
-                    }
-                    if let target = game.entities[entity[.card_target]],
-                        entity.has(tag: .card_target),
-                        target.isMinion {
-                        exclude.append(CardIds.Secrets.Mage.Spellbender)
-                    }
-                    exclude.append(CardIds.Secrets.Hunter.CatTrick)
-                } catch {
-                    logger.error("\(error)")
+                if let target = game.entities[entity[.card_target]],
+                    entity.has(tag: .card_target),
+                    target.isMinion {
+                    exclude.append(CardIds.Secrets.Mage.Spellbender)
                 }
+                exclude.append(CardIds.Secrets.Hunter.CatTrick)
             }
-        } else if entity.isMinion && game.playerMinionCount > 3 {
-            exclude.append(CardIds.Secrets.Paladin.SacredTrial)
         }
+        
         self.exclude(cardIds: exclude)
     }
 

--- a/HSTracker/Logging/Game.swift
+++ b/HSTracker/Logging/Game.swift
@@ -631,6 +631,12 @@ class Game: NSObject, PowerEventHandler {
             .first { $0.isInPlay && $0.isMinion
                 && $0.isControlled(by: self.opponent.id) } != nil
     }
+    
+    var isPlayerMinionInPlay: Bool {
+        return entities.map { $0.1 }
+            .first { $0.isInPlay && $0.isMinion
+                && $0.isControlled(by: self.player.id) && !$0.has(tag: GameTag.to_be_destroyed) } != nil
+    }
 
     var opponentMinionCount: Int {
         return entities.map { $0.1 }
@@ -1392,7 +1398,7 @@ class Game: NSObject, PowerEventHandler {
             player.secretPlayedFromDeck(entity: entity, turn: turn)
         case .hand:
             player.secretPlayedFromHand(entity: entity, turn: turn)
-            secretsManager?.handleCardPlayed(entity: entity)
+            secretsManager?.handleSpellCasted(entity: entity)
         default:
             player.createInSecret(entity: entity, turn: turn)
             return
@@ -1442,10 +1448,8 @@ class Game: NSObject, PowerEventHandler {
             playerMinionDeath(entity: entity)
         }
         
-        // a workaround to fix (#1080) by double-checking the secrets after a spell takes effect,
-        // e.g., summoned a minion.
         if playersTurn && entity.isSpell {
-            secretsManager?.handleCardPlayed(entity: entity)
+            secretsManager?.handleSpellCasted(entity: entity)
         }
         
         updateTrackers()


### PR DESCRIPTION
This PR fixes #1083 and fixes #1084 

Secrets manager now handles spells when they are moved from play to graveyard, instead of when they are moved from hand to play. It has benefits as follows by doing so:
1. we know if the spell is countered by Counterspell
2. we know the result of the spell, e.g., minions are summoned or killed, which decides if Pressure Plate is triggered or not

Test cases for these changes are also added.