### PR TITLE
Fix probabilities for opponent having a card in hand

### DIFF
--- a/HSTracker/UIs/Trackers/Tracker.swift
+++ b/HSTracker/UIs/Trackers/Tracker.swift
@@ -510,15 +510,20 @@ class Tracker: OverWindowController {
                     hand1 = 100
                     hand2 = 100
                 } else {
-                    let handMinusCoin = handCount - (hasCoin == true ? 1 : 0)
-                    let deckPlusHand = deckCount + handMinusCoin
+                    let maxDeckSize = max(30, deckCount)
 
-                    // probabilities a given card (and a second one) are still in the deck
-                    let prob1 = Double(deckCount - 1) / Double(deckPlusHand)
-                    let prob2 = prob1 * Double(deckCount - 2) / Double(deckPlusHand - 1)
+                    // Deck size after the opponent draws
+                    let nextDeckSize = deckCount - 1
 
-                    hand1 = 100 * (1 - prob1)
-                    hand2 = 100 * (1 - prob2)
+                    // probability a given card has been drawn if there is one copy in the deck
+                    hand1 = Double(maxDeckSize - nextDeckSize) / Double(maxDeckSize)
+
+                    // probability a given card has been drawn if there are two copies in the deck
+                    let prob2 = Double((maxDeckSize - 1) - nextDeckSize) / Double(maxDeckSize - 1)
+                    hand2 = 2 * hand1 - (hand1 * prob2)
+
+                    hand1 *= 100
+                    hand2 *= 100
                 }
             }
             opponentDrawChance?.drawChance1 = draw1


### PR DESCRIPTION
Currently, the probability of an opponent having a card is computed by assuming that the card is placed randomly in either the opponents hand or deck. This is not really an accurate predictor as to if the opponent has drawn the card or not. 

Consider the following example:

The opponent has 3 cards in hand and 11 cards in their deck. Assuming they haven't shuffled any additional cards into their deck, and haven't added any cards (except for maybe the original coin) to their hand, the existing algorithm would compute the probability as follows:

if running one of: 28.57% chance in hand
if running two of: 50.55% chance in hand

While the proposed change would compute these probabilities instead:

Computed 1:  66.66%
Computed 2:  89.65%

This makes more sense. If the opponent has drawn 2/3 of their entire deck, the probability of having any given card in their hand will be 2/3 (assuming they haven't played it already). The probability if they're running two of is computed using the formula P(A∪B)=P(A)+P(B)−P(A∩B)