### PR TITLE
Improve zh-Hans translations

### DIFF
--- a/HSTracker/UIs/Preferences/zh-Hans.lproj/BattlegroundsPreferences.strings
+++ b/HSTracker/UIs/Preferences/zh-Hans.lproj/BattlegroundsPreferences.strings
@@ -1,15 +1,27 @@
 
 /* Class = "NSButtonCell"; title = "Always show average damage"; ObjectID = "LKm-DE-YdT"; */
-"LKm-DE-YdT.title" = "Always show average damage";
+"LKm-DE-YdT.title" = "总是显示平均伤害";
 
 /* Class = "NSButtonCell"; title = "Show Bob's Buddy during combat"; ObjectID = "QMN-RN-SBa"; */
-"QMN-RN-SBa.title" = "Show Bob's Buddy during combat";
+"QMN-RN-SBa.title" = "在战斗中显示鲍勃助手";
 
 /* Class = "NSButtonCell"; title = "Show turn counter"; ObjectID = "c2t-Sg-vNs"; */
-"c2t-Sg-vNs.title" = "Show turn counter";
+"c2t-Sg-vNs.title" = "显示回合计数器";
 
 /* Class = "NSButtonCell"; title = "Show Bob's Buddy"; ObjectID = "i84-xc-QhF"; */
-"i84-xc-QhF.title" = "Show Bob's Buddy";
+"i84-xc-QhF.title" = "显示鲍勃助手";
 
 /* Class = "NSButtonCell"; title = "Show Bob's Buddy during shopping"; ObjectID = "rPF-4f-O8s"; */
-"rPF-4f-O8s.title" = "Show Bob's Buddy during shopping";
+"rPF-4f-O8s.title" = "在商店中显示鲍勃助手";
+
+/* Class = "NSButtonCell"; title = "Show opponent warband"; ObjectID = "J07-pk-b78"; */
+"J07-pk-b78.title" = "显示对手阵容";
+
+/* Class = "NSButtonCell"; title = "Show tiers"; ObjectID = "4LE-h7-rfX"; */
+"4LE-h7-rfX.title" = "显示酒馆等级";
+
+/* Class = "NSButtonCell"; title = "Show tavern and triple history"; ObjectID = "nGc-Fs-IbI"; */
+"nGc-Fs-IbI.title" = "显示酒馆升级和三连历史";
+
+/* Class = "NSButtonCell"; title = "Show hero comparision"; ObjectID = "oXq-kH-uaV"; */
+"oXq-kH-uaV.title" = "显示英雄对比";

--- a/HSTracker/UIs/Preferences/zh-Hans.lproj/OpponentTrackersPreferences.strings
+++ b/HSTracker/UIs/Preferences/zh-Hans.lproj/OpponentTrackersPreferences.strings
@@ -43,3 +43,9 @@
 
 /* Class = "NSButtonCell"; title = "Prevent tracker from covering opponent's name"; ObjectID = "rrt-Fg-VGw"; */
 "rrt-Fg-VGw.title" = "避免记牌器挡住对手的名字";
+
+/* Class = "NSButtonCell"; title = "Show Galakrond invoke counter"; ObjectID = "d7f-oO-njY"; */
+"d7f-oO-njY.title" = "显示迦拉克隆计数器";
+
+/* Class = "NSButtonCell"; title = "Show Libram counter"; ObjectID = "0rm-Kh-0Ob"; */
+"0rm-Kh-0Ob.title" = "显示圣契计数器";

--- a/HSTracker/UIs/Preferences/zh-Hans.lproj/PlayerTrackersPreferences.strings
+++ b/HSTracker/UIs/Preferences/zh-Hans.lproj/PlayerTrackersPreferences.strings
@@ -43,3 +43,15 @@
 
 /* Class = "NSButtonCell"; title = "Show Jade Counter"; ObjectID = "MDW-Ea-Q6M"; */
 "MDW-Ea-Q6M.title" = "显示青玉魔像计数器";
+
+/* Class = "NSButtonCell"; title = "Show Galakrond invoke counter"; ObjectID = "hcz-Gp-orK"; */
+"hcz-Gp-orK.title" = "显示迦拉克隆计数器";
+
+/* Class = "NSButtonCell"; title = "Show Libram counter"; ObjectID = "o5X-sj-pxz"; */
+"o5X-sj-pxz.title" = "显示圣契计数器";
+
+/* Class = "NSButtonCell"; title = "Show top cards"; ObjectID = "h9o-98-HVl"; */
+"h9o-98-HVl.title" = "显示牌库顶卡牌";
+
+/* Class = "NSButtonCell"; title = "Show bottom cards"; ObjectID = "JNf-li-uCC"; */
+"JNf-li-uCC.title" = "显示牌库底卡牌";

--- a/HSTracker/UIs/Preferences/zh-Hans.lproj/TrackersPreferences.strings
+++ b/HSTracker/UIs/Preferences/zh-Hans.lproj/TrackersPreferences.strings
@@ -85,3 +85,12 @@
 
 /* Class = "NSButtonCell"; title = "Disable tracking in spectator mode"; ObjectID = "6n7-a6-LsZ"; */
 "6n7-a6-LsZ.title" = "在观战模式中停止记牌";
+
+/* Class = "NSButtonCell"; title = "Show experience counter"; ObjectID = "3i1-BX-ZbC"; */
+"3i1-BX-ZbC.title" = "显示经验进度";
+
+/* Class = "NSButtonCell"; title = "Show constructed mulligan"; ObjectID = "HeE-hK-rL7"; */
+"HeE-hK-rL7.title" = "显示构造调度建议";
+
+/* Class = "NSButtonCell"; title = "Show flavor text"; ObjectID = "Ehf-nl-mzO"; */
+"Ehf-nl-mzO.title" = "显示风味文字";

--- a/HSTracker/UIs/zh-Hans.lproj/MainMenu.strings
+++ b/HSTracker/UIs/zh-Hans.lproj/MainMenu.strings
@@ -112,3 +112,9 @@
 
 /* Class = "NSMenuItem"; title = "Load from file"; ObjectID = "gJj-4D-mrw"; */
 "gJj-4D-mrw.title" = "从文件加载";
+
+/* Class = "NSMenuItem"; title = "Open logs directory..."; ObjectID = "aNE-rT-1XM"; */
+"aNE-rT-1XM.title" = "打开日志目录...";
+
+/* Class = "NSMenuItem"; title = "Bug report..."; ObjectID = "3dl-ss-r23"; */
+"3dl-ss-r23.title" = "报告问题...";

--- a/Translations/macOS/zh-Hans.lproj/Localizable.strings
+++ b/Translations/macOS/zh-Hans.lproj/Localizable.strings
@@ -125,6 +125,7 @@
 "WAILING_CAVERNS" = "哀嚎洞穴";
 "STORMWIND" = "暴风城下的集结";
 "ALTERAC_VALLEY" = "奥特兰克的决裂";
+"THE_SUNKEN_CITY" = "探寻沉没之城";
 
 /* card type */
 "all_types" = "所有";
@@ -209,6 +210,7 @@
 "Awaiting Shopping Phase" = "等待随从购买阶段";
 
 /* Battlegrounds */
+"Battlegrounds" = "酒馆战棋";
 "Turn" = "回合";
 "Turns" = "回合";
 "%d turn(s) ago" = "%d 回合以前";
@@ -230,3 +232,7 @@
 "Task progress will update after the game" = "任务进度会在对战结束后更新";
 "Completed!" = "完成!";
 "Task %d: %@" = "任务 %d: %@";
+
+/* Deck Lens - Dredge */
+"On Top" = "在牌库顶";
+"On Bottom" = "在牌库底";


### PR DESCRIPTION
Improve zh-Hans translations.

By the way, why `MercenariesPreferences.xib` is in `HSTracker/UIs/Preferences/HSTracker/UIs/Preferences/Base.lproj` other than `HSTracker/UIs/Preferences/Base.lproj`? And no local strings for it. Is this a mistake?