### PR TITLE
Fix session recap not showing in BG modes

### DIFF
--- a/HSTracker/Logging/Game.swift
+++ b/HSTracker/Logging/Game.swift
@@ -481,7 +481,7 @@ class Game: NSObject, PowerEventHandler {
         
     func updateBattlegroundsSessionOverlay() {
         DispatchQueue.main.async {
-            if Settings.showSessionRecap && ((self.currentMode == .bacon) || (self.isBattlegroundsMatch() && !self.isInMenu)) && (Settings.hideAllWhenGameInBackground && (self.hearthstoneRunState.isActive || self.selfAppActive))
+            if Settings.showSessionRecap && ((self.currentMode == .bacon) || (self.isBattlegroundsMatch() && !self.isInMenu)) && (!Settings.hideAllWhenGameInBackground && (self.hearthstoneRunState.isActive || self.selfAppActive))
                 || (!Settings.hideAllWhenGameInBackground && self.currentMode == .bacon) {
                 self.windowManager.battlegroundsSession.show()
 


### PR DESCRIPTION
Resolve #1263 

I fixed the bug "BattlegroundsSession can not be seen in game modes."

Now, it can be seen in game modes as below.

![스크린샷 2022-06-04 오전 2 05 02](https://user-images.githubusercontent.com/36851531/171912409-430fef7d-b75e-4935-b7f0-b945a77aed56.png)

**FYI**.
I already checked this change does not effect other modes. It means BattlegroundsSession is not shown when people play other game modes.