### PR TITLE
Fix Session recap shows empty box

### DIFF
--- a/HSTracker/Logging/Game.swift
+++ b/HSTracker/Logging/Game.swift
@@ -483,7 +483,7 @@ class Game: NSObject, PowerEventHandler {
         DispatchQueue.main.async {
             let isBG = (self.isBattlegroundsMatch() && (self.currentMode == .bacon || self.currentMode == .gameplay)) || self.currentMode == .bacon
 
-            if isBG && Settings.showSessionRecap && ((Settings.hideAllWhenGameInBackground && self.hearthstoneRunState.isActive) || !Settings.hideAllWhenGameInBackground) {
+            if isBG && Settings.showSessionRecap && self.isAnyBattlegroundsSessionSettingActive() && ((Settings.hideAllWhenGameInBackground && self.hearthstoneRunState.isActive) || !Settings.hideAllWhenGameInBackground) {
                 self.windowManager.battlegroundsSession.show()
 
                 var rect = SizeHelper.battlegroundsSessionFrame()
@@ -1896,6 +1896,10 @@ class Game: NSObject, PowerEventHandler {
         // TODO: remove
         return currentGameType == .gt_battlegrounds || currentGameType == .gt_battlegrounds_friendly
         //return true
+    }
+    
+    func isAnyBattlegroundsSessionSettingActive() -> Bool {
+        return Settings.showBannedTribes || Settings.showMMR || Settings.showLatestGames
     }
     
     func isMercenariesMatch() -> Bool {


### PR DESCRIPTION
Now session recap show empty box ( like below ), when all setting values ( ex) `show mmr` ) are disabled.
 
![스크린샷 2022-06-06 오후 10 29 42](https://user-images.githubusercontent.com/36851531/172171945-77fc5372-f2a6-43cf-bda5-002443a60767.png)

![스크린샷 2022-06-06 오후 10 40 06](https://user-images.githubusercontent.com/36851531/172172015-1b3c9e0f-18a1-45d3-a3a4-33e3bceaff76.png)

I added some code for not showing session recap when all setting values are disabled.

If u intend to show empty box, I'm gonna close this PR. Thx!
