### PR TITLE
fix: fix getCardChoices causes crash in some caese

### DIFF
--- a/HSTracker.xcodeproj/project.pbxproj
+++ b/HSTracker.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		1CCB4ACF1E84708A003FD1AD /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 433554321D5F6B4400277B27 /* libz.tbd */; };
 		1CCB4AEB1E8A4930003FD1AD /* LogEventHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CCB4AEA1E8A4930003FD1AD /* LogEventHandlers.swift */; };
 		1CF204F91E83B74300037A42 /* MirrorHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CF204F81E83B74300037A42 /* MirrorHelper.swift */; };
+		2B8623F12CAC39F1004CD0B1 /* ExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B8623F02CAC39F1004CD0B1 /* ExceptionCatcher.m */; };
 		340AAC051D0544AD0015FE33 /* StringTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340AAC041D0544AD0015FE33 /* StringTracker.swift */; };
 		43050C621E6B484D007600EA /* Hearthstone.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 43050C611E6B484D007600EA /* Hearthstone.xcassets */; };
 		4305CA471CF434E30048E7EC /* Cards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4305CA461CF434E30048E7EC /* Cards.swift */; };
@@ -864,6 +865,8 @@
 		1CF1B5891E81426D007DCBF2 /* AlgorithmTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlgorithmTests.swift; sourceTree = "<group>"; };
 		1CF1B58B1E815810007DCBF2 /* LogReaderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogReaderTests.swift; sourceTree = "<group>"; };
 		1CF204F81E83B74300037A42 /* MirrorHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MirrorHelper.swift; sourceTree = "<group>"; };
+		2B8623EF2CAC397E004CD0B1 /* ExceptionCatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExceptionCatcher.h; sourceTree = "<group>"; };
+		2B8623F02CAC39F1004CD0B1 /* ExceptionCatcher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ExceptionCatcher.m; sourceTree = "<group>"; };
 		340AAC041D0544AD0015FE33 /* StringTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringTracker.swift; sourceTree = "<group>"; };
 		43050C601E6B2C0E007600EA /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/TrackersPreferences.strings; sourceTree = "<group>"; };
 		43050C611E6B484D007600EA /* Hearthstone.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Hearthstone.xcassets; sourceTree = "<group>"; };
@@ -1824,6 +1827,8 @@
 				B8BD8452285D23C500F4F224 /* UnfairLock.swift */,
 				B804FC382944B1DA00F74CD9 /* ViewModel.swift */,
 				437B5BB21CD2439800DE0A41 /* WotogCounterHelper.swift */,
+				2B8623EF2CAC397E004CD0B1 /* ExceptionCatcher.h */,
+				2B8623F02CAC39F1004CD0B1 /* ExceptionCatcher.m */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -3007,6 +3012,7 @@
 				436F5D0C1CFD5F6A00DEB9A1 /* CardBar.swift in Sources */,
 				43E7BEB11DBB81B10057DC0C /* RealmCard.swift in Sources */,
 				43EBA3A31D1299AC0093B1C2 /* CardHudContainer.swift in Sources */,
+				2B8623F12CAC39F1004CD0B1 /* ExceptionCatcher.m in Sources */,
 				4361D8341DC8A21800D831CF /* BnetGameType.swift in Sources */,
 				B8AF0C6B2B83A7AD00B65F63 /* MulliganGuideParams.swift in Sources */,
 				B82F4EB024E32C3000905024 /* SimulatorProxy.swift in Sources */,

--- a/HSTracker/HSTracker-Bridging-Header.h
+++ b/HSTracker/HSTracker-Bridging-Header.h
@@ -19,6 +19,7 @@
 /*#import <UnityPack/UnityPack-Swift.h>*/
 
 #import "FileUtils.h"
+#import "ExceptionCatcher.h"
 
 #include <mono/jit/jit.h>
 #include <mono/metadata/assembly.h>

--- a/HSTracker/HearthMirror/MirrorHelper.swift
+++ b/HSTracker/HearthMirror/MirrorHelper.swift
@@ -387,7 +387,15 @@ struct MirrorHelper {
     static func getCardChoices() -> MirrorCardChoices? {
         var result: MirrorCardChoices?
         MirrorHelper.accessQueue.sync {
-            result = mirror?.getCardChoices()
+            do {
+                try ExceptionCatcher.catchException {
+                    result = mirror?.getCardChoices()
+                }
+            }
+            catch {
+                print("An error ocurred from getCardChoices: \(error)")
+            }
+            
         }
         return result
     }

--- a/HSTracker/Utility/ExceptionCatcher.h
+++ b/HSTracker/Utility/ExceptionCatcher.h
@@ -1,0 +1,20 @@
+//
+//  ExceptionCatcher.h
+//  HSTracker
+//
+//  Created by flytam on 1/10/2024.
+//  Copyright © 2024 Benjamin Michotte. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ExceptionCatcher : NSObject
+
++ (BOOL)catchException:(void(^)(void))tryBlock error:(__autoreleasing NSError **)error;
+
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/HSTracker/Utility/ExceptionCatcher.m
+++ b/HSTracker/Utility/ExceptionCatcher.m
@@ -1,0 +1,25 @@
+//
+//  ExceptionCatcher.m
+//  HSTracker
+//
+//  Created by flytam on 1/10/2024.
+//  Copyright © 2024 Benjamin Michotte. All rights reserved.
+//
+
+#import "ExceptionCatcher.h"
+
+@implementation ExceptionCatcher
+
++ (BOOL)catchException:(void(^)(void))tryBlock error:(__autoreleasing NSError **)error {
+    @try {
+        tryBlock();
+        return YES;
+    }
+    @catch (NSException *exception) {
+        *error = [[NSError alloc] initWithDomain:exception.name code:0 userInfo:exception.userInfo];
+        return NO;
+    }
+}
+
+@end
+


### PR DESCRIPTION
On the M1 MacBook Pro, HSTracker encountered a crash frenquently. **This is a rather terrible experience!**

After local code debugging, seems that it was found that the exception is thrown by the Hearthstone's `mirror?.getCardChoices` 

<img width="1514" alt="image" src="https://github.com/user-attachments/assets/5f84c5cc-6a5a-4369-a52b-610c0f269e82">

This doesn't happen every time the call is made, but only under certain circumstances. By adding an Objective-C bridging method to catch the exception, everything runs normally in Hearthstone. 

I have also tried a few matches with the fixed code, and there were no crashes. HSTracker is running perfectly.

I'm not sure if this is the correct fix, but it works for me, and this fix won't cause any breaking changes.

Closes: #1349 
