### PR TITLE
Battlegrounds UX clarity

### DIFF
--- a/HSTracker.xcodeproj/project.pbxproj
+++ b/HSTracker.xcodeproj/project.pbxproj
@@ -17,6 +17,10 @@
 		1CCB4AEB1E8A4930003FD1AD /* LogEventHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CCB4AEA1E8A4930003FD1AD /* LogEventHandlers.swift */; };
 		1CF204F91E83B74300037A42 /* MirrorHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CF204F81E83B74300037A42 /* MirrorHelper.swift */; };
 		340AAC051D0544AD0015FE33 /* StringTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340AAC041D0544AD0015FE33 /* StringTracker.swift */; };
+		3C44E25B2E0B3F0700BB7316 /* BattlegroundsStatsPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C44E25A2E0B3F0700BB7316 /* BattlegroundsStatsPicker.swift */; };
+		3C44E25D2E0B3F3D00BB7316 /* StatTier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C44E25C2E0B3F3D00BB7316 /* StatTier.swift */; };
+		3C44E25F2E0B437400BB7316 /* PickData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C44E25E2E0B437400BB7316 /* PickData.swift */; };
+		3C44E2612E0B457700BB7316 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3C44E2602E0B457700BB7316 /* Colors.xcassets */; };
 		43050C621E6B484D007600EA /* Hearthstone.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 43050C611E6B484D007600EA /* Hearthstone.xcassets */; };
 		4305CA471CF434E30048E7EC /* Cards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4305CA461CF434E30048E7EC /* Cards.swift */; };
 		4308EB7E1D76AFE6000897C8 /* ReleaseChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4308EB7D1D76AFE6000897C8 /* ReleaseChannel.swift */; };
@@ -1314,6 +1318,10 @@
 		1CF1B58B1E815810007DCBF2 /* LogReaderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogReaderTests.swift; sourceTree = "<group>"; };
 		1CF204F81E83B74300037A42 /* MirrorHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MirrorHelper.swift; sourceTree = "<group>"; };
 		340AAC041D0544AD0015FE33 /* StringTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringTracker.swift; sourceTree = "<group>"; };
+		3C44E25A2E0B3F0700BB7316 /* BattlegroundsStatsPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BattlegroundsStatsPicker.swift; sourceTree = "<group>"; };
+		3C44E25C2E0B3F3D00BB7316 /* StatTier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatTier.swift; sourceTree = "<group>"; };
+		3C44E25E2E0B437400BB7316 /* PickData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickData.swift; sourceTree = "<group>"; };
+		3C44E2602E0B457700BB7316 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		43050C601E6B2C0E007600EA /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/TrackersPreferences.strings; sourceTree = "<group>"; };
 		43050C611E6B484D007600EA /* Hearthstone.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Hearthstone.xcassets; sourceTree = "<group>"; };
 		4305CA461CF434E30048E7EC /* Cards.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cards.swift; sourceTree = "<group>"; };
@@ -2548,6 +2556,16 @@
 			path = Parsers;
 			sourceTree = "<group>";
 		};
+		3C44E2592E0B3ED700BB7316 /* PickInfo */ = {
+			isa = PBXGroup;
+			children = (
+				3C44E25A2E0B3F0700BB7316 /* BattlegroundsStatsPicker.swift */,
+				3C44E25C2E0B3F3D00BB7316 /* StatTier.swift */,
+				3C44E25E2E0B437400BB7316 /* PickData.swift */,
+			);
+			path = PickInfo;
+			sourceTree = "<group>";
+		};
 		4323C5E31E1695DD00C97896 /* HearthMirror */ = {
 			isa = PBXGroup;
 			children = (
@@ -2607,6 +2625,7 @@
 				434106A11C9868620045655A /* Assets.xcassets */,
 				434106A21C9868620045655A /* Classes.xcassets */,
 				43050C611E6B484D007600EA /* Hearthstone.xcassets */,
+				3C44E2602E0B457700BB7316 /* Colors.xcassets */,
 			);
 			path = Assets;
 			sourceTree = "<group>";
@@ -3115,6 +3134,7 @@
 		4C1923972392E174007EBB0F /* Battlegrounds */ = {
 			isa = PBXGroup;
 			children = (
+				3C44E2592E0B3ED700BB7316 /* PickInfo */,
 				4C19239C2392FA7E007EBB0F /* BattlegroundsDetailsWindow.swift */,
 				4C1923A02392FB3F007EBB0F /* BattlegroundsDetailsWindow.xib */,
 				B8BB7ABB28369C9F008239CA /* BattlegroundsFinalBoard.swift */,
@@ -4406,6 +4426,7 @@
 				439C7EE41C777FA900D29859 /* Tracker.xib in Resources */,
 				43873CC11CA6E6C200F01CB4 /* WindowMove.xib in Resources */,
 				43B695651C920BD500F4D0AC /* CardList.xib in Resources */,
+				3C44E2612E0B457700BB7316 /* Colors.xcassets in Resources */,
 				C9BDB3C81D20BC4C00886A11 /* StatsTab.xib in Resources */,
 				434106A41C9868620045655A /* Assets.xcassets in Resources */,
 				B8BD3BAA2C41C50F001E85B7 /* BattlegroundsCompositionStatsBar.xib in Resources */,
@@ -4736,6 +4757,7 @@
 				43EBA3A31D1299AC0093B1C2 /* CardHudContainer.swift in Sources */,
 				B8B790322C975B0200DD33EC /* LoveEverlastingEnchantment.swift in Sources */,
 				B81B3D8D2D4099B000DC9EB0 /* TramHeist.swift in Sources */,
+				3C44E25B2E0B3F0700BB7316 /* BattlegroundsStatsPicker.swift in Sources */,
 				4361D8341DC8A21800D831CF /* BnetGameType.swift in Sources */,
 				B8E1E5FE2D0CA1CD00383975 /* HabeasCorpses.swift in Sources */,
 				B8AF0C6B2B83A7AD00B65F63 /* MulliganGuideParams.swift in Sources */,
@@ -4826,6 +4848,7 @@
 				B8B78FE52C9676B500DD33EC /* AquaArchivistEnchantment.swift in Sources */,
 				B8B78FBC2C952A4C00DD33EC /* MagicalDollhouseEnchantment.swift in Sources */,
 				B81B3D9D2D4129F000DC9EB0 /* LiftOff.swift in Sources */,
+				3C44E25D2E0B3F3D00BB7316 /* StatTier.swift in Sources */,
 				B804FC392944B1DA00F74CD9 /* ViewModel.swift in Sources */,
 				B8B78FC42C952C5600DD33EC /* TrailMixEnchantment.swift in Sources */,
 				B8B790592C97841400DD33EC /* CommanderUlthokEnchantment.swift in Sources */,
@@ -4980,6 +5003,7 @@
 				439212151DEF5A5E0017AAE5 /* MultiClassGroup.swift in Sources */,
 				434EAC961DBCD3E8009C7636 /* NSAlert.swift in Sources */,
 				B8B78FFC2C970B7500DD33EC /* CoilfangConstrictorEnchantment.swift in Sources */,
+				3C44E25F2E0B437400BB7316 /* PickData.swift in Sources */,
 				434910501D09770000B22DB2 /* PlayerBoard.swift in Sources */,
 				B89865642D8E157600BA5649 /* PendantOfEarth.swift in Sources */,
 				B898994D2CA450720011B184 /* BattlegroundsTrinketPickState.swift in Sources */,

--- a/HSTracker/Assets/Colors.xcassets/PickHeader.colorset/Contents.json
+++ b/HSTracker/Assets/Colors.xcassets/PickHeader.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.216",
+          "green" : "0.094",
+          "red" : "0.200"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.216",
+          "green" : "0.094",
+          "red" : "0.200"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HSTracker/Assets/Colors.xcassets/TrackerBackground.colorset/Contents.json
+++ b/HSTracker/Assets/Colors.xcassets/TrackerBackground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.086",
+          "green" : "0.082",
+          "red" : "0.078"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.086",
+          "green" : "0.082",
+          "red" : "0.078"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HSTracker/UIs/Battlegrounds/HeroPicking/BattlegroundsSingleHeroStats.swift
+++ b/HSTracker/UIs/Battlegrounds/HeroPicking/BattlegroundsSingleHeroStats.swift
@@ -7,11 +7,12 @@
 //
 
 import Foundation
+import SwiftUI
 
 class BattlegroundsSingleHeroStats: NSView {
     @IBOutlet var contentView: NSView!
     
-    @IBOutlet var battlegroundsHeroHeader: BattlegroundsHeroHeader!
+    @IBOutlet var battlegroundsHeroHeader: NSView!
     @IBOutlet var heroPortraitContainer: NSView!
     @IBOutlet var compositions: BattlegroundsCompositionPopularity!
     
@@ -62,7 +63,17 @@ class BattlegroundsSingleHeroStats: NSView {
         heroPortraitContainer.addTrackingArea(trackingArea)
 
         compositions.viewModel = viewModel.bgsCompsPopularityVM
-        battlegroundsHeroHeader.viewModel = viewModel.bgsHeroHeaderVM
+        
+        let heroStatFrame = NSRect(x: 28, y: 470, width: 236, height: 72);
+        if #available(macOS 10.15, *) {
+            battlegroundsHeroHeader = NSHostingView(rootView: BattlegroundsStatsPicker(viewModel: viewModel.bgsHeroHeaderVM))
+            battlegroundsHeroHeader.frame = heroStatFrame
+        } else {
+            let view = BattlegroundsHeroHeader(frame: heroStatFrame)
+            view.viewModel = viewModel.bgsHeroHeaderVM
+            battlegroundsHeroHeader = view
+        }
+        addSubview(battlegroundsHeroHeader)
         
         update()
     }

--- a/HSTracker/UIs/Battlegrounds/HeroPicking/BattlegroundsSingleHeroStats.xib
+++ b/HSTracker/UIs/Battlegrounds/HeroPicking/BattlegroundsSingleHeroStats.xib
@@ -2,14 +2,13 @@
 <document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22689"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22690"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="BattlegroundsSingleHeroStats" customModule="HSTracker" customModuleProvider="target">
             <connections>
                 <outlet property="armorTierTooltipRange" destination="ltz-0w-Isv" id="ZCa-Br-y9q"/>
-                <outlet property="battlegroundsHeroHeader" destination="dJn-dd-3p5" id="2M5-ai-Xdl"/>
                 <outlet property="compositions" destination="5q0-Cd-eRk" id="wMX-p5-ikQ"/>
                 <outlet property="contentView" destination="c22-O7-iKe" id="NUa-12-oO3"/>
                 <outlet property="heroPortraitContainer" destination="u1e-O1-gPf" id="uAr-60-nrV"/>
@@ -18,24 +17,24 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="c22-O7-iKe" userLabel="BattlegroundsSingleHero">
-            <rect key="frame" x="0.0" y="0.0" width="266" height="568"/>
+            <rect key="frame" x="0.0" y="0.0" width="260" height="568"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <customView translatesAutoresizingMaskIntoConstraints="NO" id="dJn-dd-3p5" customClass="BattlegroundsHeroHeader" customModule="HSTracker" customModuleProvider="target">
-                    <rect key="frame" x="15" y="496" width="236" height="72"/>
+                <customView translatesAutoresizingMaskIntoConstraints="NO" id="dJn-dd-3p5">
+                    <rect key="frame" x="12" y="496" width="236" height="72"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="236" id="6EJ-DD-qF4"/>
                         <constraint firstAttribute="height" constant="72" id="V4j-aR-g3F"/>
                     </constraints>
                 </customView>
-                <customView translatesAutoresizingMaskIntoConstraints="NO" id="u1e-O1-gPf" userLabel="HeroPortraitContainer">
-                    <rect key="frame" x="15" y="132" width="236" height="364"/>
+                <customView misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="u1e-O1-gPf" userLabel="HeroPortraitContainer">
+                    <rect key="frame" x="12" y="132" width="230" height="364"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="236" id="Evg-vn-ueL"/>
                     </constraints>
                 </customView>
                 <customView hidden="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5q0-Cd-eRk" userLabel="Compositions" customClass="BattlegroundsCompositionPopularity" customModule="HSTracker" customModuleProvider="target">
-                    <rect key="frame" x="15" y="0.0" width="236" height="72"/>
+                    <rect key="frame" x="12" y="0.0" width="236" height="72"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="236" id="3TF-VP-H0t"/>
                         <constraint firstAttribute="height" constant="72" id="Aqz-dS-TZg"/>
@@ -70,7 +69,7 @@
                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="5OH-eu-5bq">
                         <rect key="frame" x="0.0" y="-2" width="169" height="88"/>
                         <subviews>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Z61-9S-dVs">
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Z61-9S-dVs">
                                 <rect key="frame" x="6" y="62" width="157" height="22"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="22" id="Il1-tv-yoM"/>
@@ -81,7 +80,7 @@
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="0kR-WP-yxU">
+                            <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="0kR-WP-yxU">
                                 <rect key="frame" x="6" y="20" width="157" height="42"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="42" id="Dfo-yv-4Xz"/>
@@ -92,7 +91,7 @@
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5hA-bl-Zuo" userLabel="ArmorTooltipRange">
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5hA-bl-Zuo" userLabel="ArmorTooltipRange">
                                 <rect key="frame" x="6" y="7" width="157" height="13"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="ArmorTooltipRange" id="yQO-8l-IQq">
                                     <font key="font" metaFont="system" size="10"/>

--- a/HSTracker/UIs/Battlegrounds/PickInfo/BattlegroundsStatsPicker.swift
+++ b/HSTracker/UIs/Battlegrounds/PickInfo/BattlegroundsStatsPicker.swift
@@ -1,0 +1,114 @@
+//
+//  BackgroundsPickers.swift
+//  HSTracker
+//
+//  Created by IHume on 2025-06-20.
+//  Copyright © 2025 Benjamin Michotte. All rights reserved.
+//
+
+import SwiftUI
+
+@available(macOS 10.15, *)
+struct BattlegroundsStatsPicker: View {
+    let viewModel: StatsHeaderViewModel
+    let itemHasCost: Bool
+    
+    init(viewModel: StatsHeaderViewModel) {
+        self.viewModel = viewModel
+        self.itemHasCost = false
+    }
+    
+    init(viewModel: StatsHeaderViewModel, itemHasCost: Bool) {
+        self.viewModel = viewModel
+        self.itemHasCost = itemHasCost
+    }
+
+    var body: some View {
+        let placementString = if let placement = viewModel.avgPlacement {
+            "\(Double(round(100 * placement) / 100))"
+        } else {
+            "—"
+        }
+        let pickRateString = if let pickRate = viewModel.pickRate {
+            "\(Double(round(10 * pickRate) / 10))%"
+        } else {
+            "—"
+        }
+
+        return HStack(alignment: .top, spacing: 3, content: {
+            PickData(
+                title: "Avg Placement",
+                value: placementString,
+                clipSide: itemHasCost ? .RightIcon : .RightPortrait,
+                color: Color(hex: viewModel.avgPlacementColor)
+            ).padding([.top], itemHasCost ? 30 : 0)
+            StatTier(tier: Tier(rawValue: viewModel.tierChar) ?? Tier.A)
+            PickData(
+                title: "Pick Rate",
+                value: pickRateString,
+                clipSide: itemHasCost ? .LeftIcon : .LeftPortrait
+            ).padding([.top], itemHasCost ? 30 : 0)
+        })
+    }
+}
+
+@available(macOS 10.15, *)
+// Extend SwiftUI color to be able to accept hex string that avgPlacementColor is generating
+// from the placement value. Implementation from: https://blog.eidinger.info/from-hex-to-color-and-back-in-swiftui
+extension Color {
+    init?(hex: String) {
+        var hexSanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        hexSanitized = hexSanitized.replacingOccurrences(of: "#", with: "")
+
+        var rgb: UInt64 = 0
+
+        var r: CGFloat = 0.0
+        var g: CGFloat = 0.0
+        var b: CGFloat = 0.0
+        var a: CGFloat = 1.0
+
+        let length = hexSanitized.count
+
+        guard Scanner(string: hexSanitized).scanHexInt64(&rgb) else { return nil }
+
+        if length == 6 {
+            r = CGFloat((rgb & 0xFF0000) >> 16) / 255.0
+            g = CGFloat((rgb & 0x00FF00) >> 8) / 255.0
+            b = CGFloat(rgb & 0x0000FF) / 255.0
+
+        } else if length == 8 {
+            r = CGFloat((rgb & 0xFF000000) >> 24) / 255.0
+            g = CGFloat((rgb & 0x00FF0000) >> 16) / 255.0
+            b = CGFloat((rgb & 0x0000FF00) >> 8) / 255.0
+            a = CGFloat(rgb & 0x000000FF) / 255.0
+
+        } else {
+            return nil
+        }
+
+        self.init(red: r, green: g, blue: b, opacity: a)
+    }
+}
+
+@available(macOS 10.15, *)
+#Preview {
+    return VStack {
+        BattlegroundsStatsPicker(
+            viewModel:
+                StatsHeaderViewModel(
+                    tier: "s",
+                    avgPlacement: 3.12,
+                    pickRate: 26.3
+                )
+        )
+        BattlegroundsStatsPicker(
+            viewModel:
+                StatsHeaderViewModel(
+                    tier: "a",
+                    avgPlacement: 3.12,
+                    pickRate: 26.3
+                ),
+            itemHasCost: true
+        )
+    }
+}

--- a/HSTracker/UIs/Battlegrounds/PickInfo/PickData.swift
+++ b/HSTracker/UIs/Battlegrounds/PickInfo/PickData.swift
@@ -1,0 +1,142 @@
+//
+//  PickData.swift
+//  HSTracker
+//
+//  Created by IHume on 2025-06-24.
+//  Copyright © 2025 Benjamin Michotte. All rights reserved.
+//
+
+import SwiftUI
+
+@available(macOS 10.15, *)
+struct PickDataContainerRight: Shape {
+    let portraitCurve: Bool;
+
+    func path(in rect: CGRect) -> Path {
+        Path { path in
+            let curveOffset: CGFloat = 25
+            let controlOffset: CGFloat = 22
+            path.move(to: CGPoint(
+                x: rect.maxX - (portraitCurve ? curveOffset + 12 : curveOffset + 8),
+                y: rect.maxY
+            ))
+            path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+            path.addLine(to: CGPoint(x: rect.minX, y: rect.minY))
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY - curveOffset ))
+            path.addQuadCurve(
+                to: CGPoint(
+                    x: rect.maxX - (portraitCurve ? curveOffset + 12 : curveOffset + 8),
+                    y: rect.maxY
+                ),
+                control: CGPoint(
+                    x: rect.midX + (portraitCurve ? controlOffset + 3 : controlOffset + 3),
+                    y: rect.midY + (portraitCurve ? controlOffset + 3 : controlOffset + 3))
+            )
+        }
+    }
+}
+
+@available(macOS 10.15, *)
+struct PickDataContainerLeft: Shape {
+    let portraitCurve: Bool;
+
+    func path(in rect: CGRect) -> Path {
+        Path { path in
+            let curveOffset: CGFloat = 25
+            let controlOffset: CGFloat = 22
+            path.move(to: CGPoint(
+                x: rect.minX + (portraitCurve ? curveOffset + 12 : curveOffset + 8),
+                y: rect.maxY
+            ))
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
+            path.addLine(to: CGPoint(x: rect.minX, y: rect.minY))
+            path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY - curveOffset ))
+            path.addQuadCurve(
+                to: CGPoint(
+                    x: rect.minX + (portraitCurve ? curveOffset + 12 : curveOffset + 8),
+                    y: rect.maxY),
+                control: CGPoint(
+                    x: rect.midX - (portraitCurve ? controlOffset + 3 : controlOffset + 3),
+                    y: rect.midY + (portraitCurve ? controlOffset + 3 : controlOffset + 3))
+            )
+        }
+    }
+}
+
+enum ClipDirection {
+    case RightIcon
+    case LeftIcon
+    case RightPortrait
+    case LeftPortrait
+}
+
+@available(macOS 10.15, *)
+struct PickData: View {
+    let title: String
+    let value: String
+    let color: Color
+    let clipSide: ClipDirection?
+    
+    init(title: String, value: String, clipSide: ClipDirection?) {
+        self.title = title
+        self.value = value
+        self.color = Color.white
+        self.clipSide = clipSide
+    }
+    
+    init(title: String, value: String, clipSide: ClipDirection?, color: Color?) {
+        self.title = title
+        self.value = value
+        self.clipSide = clipSide
+        self.color = color ?? Color.white
+    }
+    
+    var body: some View {
+        return ZStack{
+            if clipSide == .RightIcon || clipSide == .RightPortrait {
+                PickDataContainerRight(portraitCurve: clipSide == .RightPortrait)
+                    .foregroundColor(Color("TrackerBackground"))
+                    .frame(width: 100, height: 75)
+            } else if clipSide == .LeftIcon || clipSide == .LeftPortrait {
+                PickDataContainerLeft(portraitCurve: clipSide == .LeftPortrait)
+                    .foregroundColor(Color("TrackerBackground"))
+                    .frame(width: 100, height: 75)
+            } else {
+                Rectangle()
+                    .foregroundColor(Color("TrackerBackground"))
+                    .frame(width: 100, height: 75)
+            }
+            VStack(spacing: 0, content: {
+                Text(title)
+                    .font(Font.system(size: 11))
+                    .foregroundColor(Color.white)
+                    .frame(width: 100, height: 25)
+                    .background(Color("PickHeader"))
+                Text(value)
+                    .foregroundColor(color)
+                    .frame(width: 100, height: 50)
+                    .font(Font.system(size: 20, weight: .bold))
+            })
+        }
+        .frame(width: 100, height: 75)
+        .cornerRadius(5)
+    }
+}
+
+@available(macOS 10.15, *)
+#Preview {
+    VStack {
+        HStack(spacing: 50, content: {
+            PickData(title: "Pick Rate", value: "14.0%", clipSide: .RightIcon)
+            PickData(title: "Pick Rate", value: "14.0%", clipSide: .LeftIcon)
+        })
+        HStack(spacing: 50, content: {
+            PickData(title: "Pick Rate", value: "14.0%", clipSide: .RightPortrait)
+            PickData(title: "Pick Rate", value: "14.0%", clipSide: .LeftPortrait)
+        })
+
+    }
+    
+}

--- a/HSTracker/UIs/Battlegrounds/PickInfo/StatTier.swift
+++ b/HSTracker/UIs/Battlegrounds/PickInfo/StatTier.swift
@@ -1,0 +1,84 @@
+//
+//  StatTier.swift
+//  HSTracker
+//
+//  Created by IHume on 2025-06-24.
+//  Copyright © 2025 Benjamin Michotte. All rights reserved.
+//
+
+import SwiftUI
+
+@available(macOS 10.15, *)
+enum Tier: String {
+    case S = "S"
+    case A = "A"
+    case B = "B"
+    case C = "C"
+    case D = "D"
+    case F = "F"
+    
+    var gradient: Gradient {
+        switch self {
+        case .S:
+            Gradient(colors: [
+                Color(red: 0.25, green: 0.54, blue: 0.75),
+                Color(red: 0.22, green: 0.37, blue: 0.48)
+            ])
+        case .A:
+            Gradient(colors: [
+                Color(red: 0.41, green: 0.61, blue: 0.21),
+                Color(red: 0.34, green: 0.47, blue: 0.21)
+            ])
+        case .B:
+            Gradient(colors: [
+                Color(red: 0.57, green: 0.63, blue: 0.21),
+                Color(red: 0.41, green: 0.47, blue: 0.21)
+            ])
+        case .C:
+            Gradient(colors: [
+                Color(red: 0.63, green: 0.48, blue: 0.21),
+                Color(red: 0.47, green: 0.37, blue: 0.21)
+            ])
+        case .D:
+            Gradient(colors: [
+                Color(red: 0.63, green: 0.28, blue: 0.21),
+                Color(red: 0.47, green: 0.26, blue: 0.21)
+            ])
+        case .F:
+            Gradient(colors: [
+                Color(red: 0.63, green: 0.21, blue: 0.21),
+                Color(red: 0.47, green: 0.21, blue: 0.21)
+            ])
+        }
+    }
+}
+
+@available(macOS 10.15, *)
+struct StatTier: View {
+    let tier: Tier
+
+    var body: some View {
+        VStack(spacing: 0, content: {
+            Text("TIER")
+                .font(Font.system(size: 11, weight: .light))
+            Text(tier.rawValue)
+                .font(Font.system(size: 22, weight: .bold))
+        })
+        .foregroundColor(Color.white)
+        .frame(width: 60, height: 60)
+        .background(LinearGradient(gradient: tier.gradient, startPoint: .top, endPoint: .bottom))
+        .cornerRadius(5)
+    }
+}
+
+@available(macOS 10.15, *)
+#Preview {
+    HStack {
+        StatTier(tier: Tier.S)
+        StatTier(tier: Tier.A)
+        StatTier(tier: Tier.B)
+        StatTier(tier: Tier.C)
+        StatTier(tier: Tier.D)
+        StatTier(tier: Tier.F)
+    }
+}

--- a/HSTracker/UIs/Battlegrounds/Session/Base.lproj/BattlegroundsSession.xib
+++ b/HSTracker/UIs/Battlegrounds/Session/Base.lproj/BattlegroundsSession.xib
@@ -2,7 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22689"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22690"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -63,10 +63,10 @@
                                                                 <rect key="frame" x="0.0" y="0.0" width="240" height="30"/>
                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                 <subviews>
-                                                                    <textField identifier="MinionsBanned" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gAn-M1-xQI" userLabel="Minions Banned">
+                                                                    <textField identifier="MinionsBanned" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gAn-M1-xQI" userLabel="Minions Banned">
                                                                         <rect key="frame" x="-2" y="6" width="244" height="18"/>
                                                                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Minions Banned" id="vrF-Hk-Z1q">
-                                                                            <font key="font" metaFont="system"/>
+                                                                            <font key="font" metaFont="systemBold"/>
                                                                             <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="deviceRGB"/>
                                                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                         </textFieldCell>
@@ -168,7 +168,7 @@
                                                                         <real value="3.4028234663852886e+38"/>
                                                                     </customSpacing>
                                                                 </stackView>
-                                                                <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WfY-6P-It1">
+                                                                <textField hidden="YES" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WfY-6P-It1">
                                                                     <rect key="frame" x="37" y="27" width="167" height="19"/>
                                                                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Waiting for next game" id="Lsj-Uu-LT0">
                                                                         <font key="font" metaFont="system" size="16"/>
@@ -235,13 +235,13 @@
                                                                         <rect key="frame" x="0.0" y="0.0" width="238" height="28"/>
                                                                         <middleViews>
                                                                             <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="f0P-Hk-d1j">
-                                                                                <rect key="frame" x="52" y="6" width="16" height="16"/>
+                                                                                <rect key="frame" x="48" y="6" width="16" height="16"/>
                                                                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="tier7-logo" id="Bp6-4v-Gbp"/>
                                                                             </imageView>
-                                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="751" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Zg8-RK-ENA">
-                                                                                <rect key="frame" x="72" y="6" width="116" height="16"/>
+                                                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="751" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Zg8-RK-ENA">
+                                                                                <rect key="frame" x="68" y="6" width="124" height="16"/>
                                                                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Composition Stats" id="dfB-qF-lgY">
-                                                                                    <font key="font" metaFont="system"/>
+                                                                                    <font key="font" metaFont="systemBold"/>
                                                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                                 </textFieldCell>
@@ -276,7 +276,7 @@
                                                                 <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="USG-JT-UWE">
                                                                     <rect key="frame" x="0.0" y="0.0" width="240" height="30"/>
                                                                     <subviews>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3Jn-cN-ufF">
+                                                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3Jn-cN-ufF">
                                                                             <rect key="frame" x="-2" y="8" width="94" height="14"/>
                                                                             <constraints>
                                                                                 <constraint firstAttribute="width" constant="90" id="CZC-o0-bmK"/>
@@ -287,7 +287,7 @@
                                                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bey-K0-x9f">
+                                                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bey-K0-x9f">
                                                                             <rect key="frame" x="88" y="8" width="74" height="14"/>
                                                                             <constraints>
                                                                                 <constraint firstAttribute="width" constant="70" id="OTh-Xa-9pk"/>
@@ -298,7 +298,7 @@
                                                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bd8-gr-w6Q">
+                                                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bd8-gr-w6Q">
                                                                             <rect key="frame" x="158" y="8" width="84" height="14"/>
                                                                             <constraints>
                                                                                 <constraint firstAttribute="width" constant="80" id="xO9-Bb-V8B"/>
@@ -335,7 +335,7 @@
                                                                 <real value="3.4028234663852886e+38"/>
                                                             </customSpacing>
                                                         </stackView>
-                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lhp-3L-tdE">
+                                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lhp-3L-tdE">
                                                             <rect key="frame" x="-2" y="58" width="244" height="58"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="240" id="F0C-c1-Tq4"/>
@@ -347,7 +347,7 @@
                                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                             </textFieldCell>
                                                         </textField>
-                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Zpf-0u-LZO">
+                                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Zpf-0u-LZO">
                                                             <rect key="frame" x="-2" y="0.0" width="244" height="58"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="240" id="6Ce-IQ-b27"/>
@@ -388,10 +388,10 @@
                                                                 <rect key="frame" x="1" y="1" width="238" height="28"/>
                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                 <subviews>
-                                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8yj-hs-1vo">
+                                                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8yj-hs-1vo">
                                                                         <rect key="frame" x="-2" y="6" width="242" height="16"/>
                                                                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="MMR" id="bGX-b0-wmd">
-                                                                            <font key="font" metaFont="system"/>
+                                                                            <font key="font" metaFont="systemBold"/>
                                                                             <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                         </textFieldCell>
@@ -412,7 +412,7 @@
                                                                 <stackView identifier="StackMMRA" distribution="fill" orientation="vertical" alignment="leading" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" verticalCompressionResistancePriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="a7j-tD-Dih" userLabel="StackMMRA">
                                                                     <rect key="frame" x="0.0" y="8" width="120" height="35"/>
                                                                     <subviews>
-                                                                        <textField identifier="LabelMMRA" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UlU-qf-Ucu" userLabel="LabelMMRA">
+                                                                        <textField identifier="LabelMMRA" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UlU-qf-Ucu" userLabel="LabelMMRA">
                                                                             <rect key="frame" x="-2" y="21" width="124" height="14"/>
                                                                             <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" placeholderString="Label A" id="LuU-FJ-jhe">
                                                                                 <font key="font" metaFont="smallSystem"/>
@@ -420,10 +420,10 @@
                                                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
-                                                                        <textField identifier="MMRFieldA" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3Fb-Zz-bUs" userLabel="MMRFieldA">
+                                                                        <textField identifier="MMRFieldA" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3Fb-Zz-bUs" userLabel="MMRFieldA">
                                                                             <rect key="frame" x="-2" y="0.0" width="124" height="21"/>
                                                                             <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="0" id="SEL-B1-bxP">
-                                                                                <font key="font" metaFont="system" size="18"/>
+                                                                                <font key="font" metaFont="systemBold" size="18"/>
                                                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
@@ -458,7 +458,7 @@
                                                                 <stackView identifier="StackMMRB" distribution="fill" orientation="vertical" alignment="leading" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" verticalCompressionResistancePriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="afI-S2-o2l" userLabel="StackMMRB">
                                                                     <rect key="frame" x="121" y="8" width="119" height="35"/>
                                                                     <subviews>
-                                                                        <textField identifier="LabelMMRB" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1m0-eg-k4m" userLabel="LabelMMRB">
+                                                                        <textField identifier="LabelMMRB" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1m0-eg-k4m" userLabel="LabelMMRB">
                                                                             <rect key="frame" x="-2" y="21" width="123" height="14"/>
                                                                             <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" placeholderString="Label B" id="qMf-il-9Tt">
                                                                                 <font key="font" metaFont="smallSystem"/>
@@ -466,10 +466,10 @@
                                                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
-                                                                        <textField identifier="MMRFieldB" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QV0-e5-Fff" userLabel="MMRFieldB">
+                                                                        <textField identifier="MMRFieldB" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QV0-e5-Fff" userLabel="MMRFieldB">
                                                                             <rect key="frame" x="-2" y="0.0" width="123" height="21"/>
                                                                             <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="0" id="9K4-TV-luB">
-                                                                                <font key="font" metaFont="system" size="18"/>
+                                                                                <font key="font" metaFont="systemBold" size="18"/>
                                                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
@@ -534,10 +534,10 @@
                                                                 <rect key="frame" x="1" y="1" width="238" height="28"/>
                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                 <subviews>
-                                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="GSw-5J-Dfv">
+                                                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="GSw-5J-Dfv">
                                                                         <rect key="frame" x="-2" y="6" width="242" height="16"/>
                                                                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Latest Games" id="EHU-ML-UQu">
-                                                                            <font key="font" metaFont="system"/>
+                                                                            <font key="font" metaFont="systemBold"/>
                                                                             <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                         </textFieldCell>
@@ -651,7 +651,7 @@
                                                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="QPM-sf-cHf" userLabel="GameEmptyState">
                                                             <rect key="frame" x="0.0" y="0.0" width="240" height="44"/>
                                                             <subviews>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="geC-v5-KHP" userLabel="No games played this session.">
+                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="geC-v5-KHP" userLabel="No games played this session.">
                                                                     <rect key="frame" x="2" y="22" width="236" height="14"/>
                                                                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="No games played this session." id="1mK-qe-hNf">
                                                                         <font key="font" metaFont="smallSystem"/>
@@ -659,7 +659,7 @@
                                                                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Byq-Yo-5Ah">
+                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Byq-Yo-5Ah">
                                                                     <rect key="frame" x="2" y="8" width="236" height="14"/>
                                                                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Latest 10 games will appear here." id="laC-ik-fnr">
                                                                         <font key="font" metaFont="smallSystem"/>

--- a/HSTracker/UIs/Battlegrounds/TrinketPicking/BattlegroundsTrinketPicking.swift
+++ b/HSTracker/UIs/Battlegrounds/TrinketPicking/BattlegroundsTrinketPicking.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 class BattlegroundsTrinketPicking: OverWindowController {
     @IBOutlet var itemsStack: NSStackView!
@@ -101,9 +102,22 @@ class BattlegroundsTrinketPicking: OverWindowController {
                     old.removeFromSuperview()
                 }
                 
+                if #available(macOS 10.15, *) {
+                    itemsStack.edgeInsets = NSEdgeInsets(top: 0, left: 20, bottom: 0, right: 0)
+                }
+                
                 if let trinketStats = viewModel.trinketStats {
                     for vm in trinketStats {
-                        let view = BattlegroundsSingleTrinket(frame: NSRect(x: 0, y: 0, width: 277, height: 430), viewModel: vm)
+                        let view = if #available(macOS 10.15, *) {
+                            NSHostingView(
+                                rootView: BattlegroundsStatsPicker(
+                                    viewModel: vm, itemHasCost: true
+                                ))
+                        } else {
+                            BattlegroundsSingleTrinket(
+                                frame: NSRect(x: 0, y: 0, width: 277, height: 430),
+                                viewModel: vm)
+                        }
                         itemsStack.addArrangedSubview(view)
                     }
                 }

--- a/HSTracker/UIs/Battlegrounds/TrinketPicking/BattlegroundsTrinketPicking.xib
+++ b/HSTracker/UIs/Battlegrounds/TrinketPicking/BattlegroundsTrinketPicking.xib
@@ -2,7 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22689"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22690"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -37,7 +37,7 @@
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                         <subviews>
                                             <stackView identifier="ItemsStackView" distribution="fillEqually" orientation="horizontal" alignment="top" spacing="25" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="249.99998474121094" horizontalHuggingPriority="1000" detachesHiddenViews="YES" id="WBY-0s-1SQ" userLabel="Items" colorLabel="IBBuiltInLabel-Red">
-                                                <rect key="frame" x="0.0" y="0.0" width="1108" height="430"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="1104" height="430"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <edgeInsets key="edgeInsets" left="12.5" right="12.5" top="0.0" bottom="0.0"/>
                                                 <constraints>
@@ -67,7 +67,7 @@
                                                 <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jYe-xE-R3Q">
                                                     <rect key="frame" x="0.0" y="0.0" width="164" height="16"/>
                                                     <subviews>
-                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="pdO-EP-vVg" userLabel="HIDE TRINKET STATS">
+                                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="pdO-EP-vVg" userLabel="HIDE TRINKET STATS">
                                                             <rect key="frame" x="-2" y="0.0" width="152" height="16"/>
                                                             <textFieldCell key="cell" lineBreakMode="clipping" title="HIDE TRINKET STATS" id="VmR-SD-QON" userLabel="HIDE TRINKET STATS">
                                                                 <font key="font" usesAppearanceFont="YES"/>


### PR DESCRIPTION
Cleans up Battlegrounds Hero & Trinket picking overlays to use the same new SwiftUi view:
Old:
<img width="1150" alt="Screenshot 2025-06-20 at 11 46 33 AM" src="https://github.com/user-attachments/assets/b3390c59-d187-459c-973e-f72255156c48" />
<img width="1831" alt="Screenshot 2025-06-20 at 11 38 52 AM" src="https://github.com/user-attachments/assets/6bc4c503-a8e3-471e-8b61-efe338bf6a20" />

New:
<img width="687" alt="Screenshot 2025-06-25 at 4 13 30 PM" src="https://github.com/user-attachments/assets/f8b6264a-1642-48b9-a2ce-826ac3eb8698" />
<img width="1081" alt="Screenshot 2025-06-25 at 4 25 26 PM" src="https://github.com/user-attachments/assets/b1797112-2554-4ac8-b6b6-c006aafb53c1" />

Additionally adds some text bolding to the battlegrounds session headers for increased clarity
