### PR TITLE
fix: "Related Cards" does not show "rewinded" cards and show initial card instead

### DIFF
--- a/HSTracker/Logging/EntityInfo.swift
+++ b/HSTracker/Logging/EntityInfo.swift
@@ -38,7 +38,12 @@ class EntityInfo {
     var storedCardIds: [String] = []
     var copyOfCardId: String?
     var latestCardId: String {
-        get { _latestCardId ?? _entity.cardId }
+        get {
+            if let id = _latestCardId, !id.isEmpty {
+                return id
+            }
+            return _entity.cardId
+        }
         set { _latestCardId = newValue }
     }
     var deckIndex = 0

--- a/HSTracker/Logging/Parsers/PowerGameStateParser.swift
+++ b/HSTracker/Logging/Parsers/PowerGameStateParser.swift
@@ -345,7 +345,9 @@ class PowerGameStateParser: LogEventParser {
                     entity.cardId.hasPrefix("CREATED_BY_") {
                     entity.cardId = cardId
                 }
-                entity.info.latestCardId = cardId
+                if !cardId.isEmpty {
+                    entity.info.latestCardId = cardId
+                }
                 if type == "SHOW_ENTITY" {
                     if entity.info.guessedCardState != GuessedCardState.none {
                         entity.info.guessedCardState = GuessedCardState.revealed

--- a/HSTracker/Logging/Parsers/PowerGameStateParser.swift
+++ b/HSTracker/Logging/Parsers/PowerGameStateParser.swift
@@ -284,6 +284,11 @@ class PowerGameStateParser: LogEventParser {
                 if let currentBlock = currentBlock, entity.cardId.uppercased().contains("HERO") {
                     currentBlock.hasFullEntityHeroPackets = true
                 }
+            } else if let cardId, !cardId.isBlank, let entity = eventHandler.entities[id] {
+                // Entity already exists but FULL_ENTITY - Updating arrived with a different CardID
+                // This happens when a Discover choice is changed via Rewind
+                entity.cardId = cardId
+                entity.info.latestCardId = cardId
             }
 
             set(currentEntity: id)

--- a/HSTracker/Logging/Parsers/TagChangeActions.swift
+++ b/HSTracker/Logging/Parsers/TagChangeActions.swift
@@ -80,8 +80,6 @@ struct TagChangeActions {
                 self.onRevealed(eventHandler: eventHandler, id: id, value: value, previous: prevValue)
             case .parent_card:
                 self.onParentCardChange(eventHandler: eventHandler, id: id, value: value, previous: prevValue)
-            case .cant_play:
-                self.cantPlayChange(eventHandler: eventHandler, id: id, value: value, previous: prevValue)
             case .health:
                 self.healthChange(eventHandler: eventHandler, id: id, value: value, previous: prevValue)
             case .maxresources:
@@ -646,19 +644,6 @@ struct TagChangeActions {
         for cardId in cardIds {
             game.opponent.predictUniqueCardInDeck(cardId: cardId, isCreated: false)
         }
-    }
-    
-    private func cantPlayChange(eventHandler: PowerEventHandler, id: Int, value: Int, previous: Int) {
-        guard let entity = eventHandler.entities[id] else {
-            return
-        }
-        
-        let player = entity.isControlled(by: eventHandler.player.id) ? eventHandler.player : eventHandler.opponent
-        player?.cardsPlayedThisMatch.remove(entity)
-        player?.cardsPlayedThisTurn.remove(entity)
-        player?.spellsPlayedCards.remove(entity)
-        player?.spellsPlayedInFriendlyCharacters.remove(entity)
-        player?.spellsPlayedInOpponentCharacters.remove(entity)
     }
     
     private func onParentCardChange(eventHandler: PowerEventHandler, id: Int, value: Int, previous: Int) {


### PR DESCRIPTION
### Issue

- Tess Greymane "Related Cards" does not show "rewinded" cards at all.
- Tess Greymane "Related Cards" does not show "rewinded" cards with "Stealth" and "Dormant" keywords

### Description:

#### Part I:

When Rewind re-picks during Discover (e.x. Rogue imbue ability), the game sends a new FULL_ENTITY - Updating for the same entity with a different `CardID`. The `CreationRegex` handler only set cardId for new entities, ignoring updates to existing ones. This caused Tess Greymane's related cards tooltip to show **the first Discover pick** instead of the actual played card.
Also remove the incorrect `cantPlayChange` handler that was a previous attempt at fixing this issue.

#### Part II:
After Part I, Rewind-Discovered cards with Stealth or Dormant keywords were still missing from the tooltip (see video). When such a card is played, the game sends SHOW_ENTITY - Updating **with a blank** `CardID`. The `UpdatingEntityRegex` handler unconditionally set `latestCardId` to that blank value, and since all zone change handlers pass `latestCardId` as the `cardId` parameter, the `playerPlay` call was skipped due to the empty `cardId` guard in `zoneChangeFromHand`.

**Before:**

https://github.com/user-attachments/assets/16cdad17-1427-4f18-bd75-ee64f6fb00b9


https://github.com/user-attachments/assets/fdf07e29-9795-4196-8f0f-dfb4a0c02a2a


**After:**

https://github.com/user-attachments/assets/7abf5d63-7673-4e7d-a9a5-f5dc6f3c8c6e


https://github.com/user-attachments/assets/3ce5388a-efc6-4f02-ab29-86f6ee38b762


