### PR TITLE
Fix Battlegrounds overlays staying visible when another app takes focus

### DIFF
--- a/HSTracker/Logging/Game.swift
+++ b/HSTracker/Logging/Game.swift
@@ -105,8 +105,10 @@ class Game: NSObject, PowerEventHandler {
     
     func setHearthstoneActived(flag: Bool) {
         hearthstoneRunState.isActive = flag
-        if flag && currentMode == .bacon || isBattlegroundsMatch() {
-            windowManager.tier7PreLobby.viewModel.onFocus()
+        if currentMode == .bacon || isBattlegroundsMatch() {
+            if flag {
+                windowManager.tier7PreLobby.viewModel.onFocus()
+            }
             updateBattlegroundsSessionVisibility()
         }
     }

--- a/HSTracker/UIs/Battlegrounds/Session/BattlegroundsGameView.swift
+++ b/HSTracker/UIs/Battlegrounds/Session/BattlegroundsGameView.swift
@@ -129,6 +129,9 @@ class BattlegroundsGameView: NSView {
         if let screenFrame = self.window?.screen?.frame ?? NSScreen.main?.frame, x + size.width >= screenFrame.maxX {
             x = window.frame.minX - 10 - size.width
         }
+        if let fbWindow = fb.window, fbWindow.parent !== window {
+            window.addChildWindow(fbWindow, ordered: .above)
+        }
         AppDelegate.instance().coreManager.game.windowManager.show(controller: fb, show: true, frame: NSRect(x: screenRect.minX + x, y: screenRect.minY, width: size.width, height: size.height), title: nil, overlay: true)
     }
     


### PR DESCRIPTION
- Fixed a bug where the Battlegrounds session/MMR overlay stayed on screen when another app took focus while the user was in the BG lobby (or had just clicked Start, before the match was registered).
- Fixed the Battlegrounds Final Board tooltip being left orphaned over other apps when Hearthstone loses focus.