### PR TITLE
Windowed mode improvements

### DIFF
--- a/HSTracker/Core/SizeHelper.swift
+++ b/HSTracker/Core/SizeHelper.swift
@@ -38,7 +38,7 @@ struct SizeHelper {
         func reload() {
             let options = CGWindowListOption(arrayLiteral: .excludeDesktopElements)
             let windowListInfo = CGWindowListCopyWindowInfo(options, CGWindowID(0))
-            
+
             if let info = (windowListInfo as? [NSDictionary])?.filter({dict in
                 dict["kCGWindowOwnerName"] as? String == CoreManager.applicationName && dict["kCGWindowLayer"] as? Int == 0 && dict["kCGWindowIsOnscreen"] as? Int == 1
             }).sorted(by: {
@@ -47,23 +47,43 @@ struct SizeHelper {
                 if let id = info["kCGWindowNumber"] as? Int {
                     self.windowId = CGWindowID(id)
                 }
-                
+
                 let pid = info["kCGWindowOwnerPID"] as? pid_t ?? 0
-                
+
                 let appRef = AXUIElementCreateApplication(pid)
                 var window: CFTypeRef?
-                
+
                 let result: AXError = AXUIElementCopyAttributeValue(appRef, kAXFocusedWindowAttribute as CFString, &window)
                 var calculateFromFrame = false
-                if result == .success {
-                    var fs: CFTypeRef?
+                // kCGWindowBounds can return a stale Mission Control thumbnail rect for some
+                // time after MC dismisses; AX reflects HS's actual NSWindow.frame.
+                var axRect: CGRect?
+                if result == .success, let axWindow = window {
                     // swiftlint:disable force_cast
-                    AXUIElementCopyAttributeValue(window as! AXUIElement, "AXFullScreen" as CFString, &fs)
+                    let axWindowRef = axWindow as! AXUIElement
                     // swiftlint:enable force_cast
+
+                    var fs: CFTypeRef?
+                    AXUIElementCopyAttributeValue(axWindowRef, "AXFullScreen" as CFString, &fs)
                     if let nsvalue = fs as? NSNumber {
                         fullscreen = nsvalue.intValue != 0
                     } else {
                         fullscreen = false
+                    }
+
+                    var posRef: CFTypeRef?
+                    var sizeRef: CFTypeRef?
+                    let posResult = AXUIElementCopyAttributeValue(axWindowRef, kAXPositionAttribute as CFString, &posRef)
+                    let sizeResult = AXUIElementCopyAttributeValue(axWindowRef, kAXSizeAttribute as CFString, &sizeRef)
+                    if posResult == .success, sizeResult == .success,
+                       let posValue = posRef, let sizeValue = sizeRef {
+                        var pos = CGPoint.zero
+                        var size = CGSize.zero
+                        // swiftlint:disable force_cast
+                        AXValueGetValue(posValue as! AXValue, .cgPoint, &pos)
+                        AXValueGetValue(sizeValue as! AXValue, .cgSize, &size)
+                        // swiftlint:enable force_cast
+                        axRect = CGRect(origin: pos, size: size)
                     }
                 } else {
                     if !SizeHelper.HearthstoneWindow.axErrorReported {
@@ -72,23 +92,22 @@ struct SizeHelper {
                     }
                     calculateFromFrame = true
                 }
-                
+
                 // swiftlint:disable force_cast
                 let bounds = info["kCGWindowBounds"] as! CFDictionary
                 // swiftlint:enable force_cast
-                if let rect = CGRect(dictionaryRepresentation: bounds) {
+                if let rect = axRect ?? CGRect(dictionaryRepresentation: bounds) {
                     var frame = rect
-                    
+
                     // Warning: this function assumes that the
                     // first screen in the list is the active one
                     if let screen = NSScreen.screens.first {
                         screenRect = screen.frame
                         frame.origin.y = screen.frame.maxY - rect.maxY
                     }
-                    
-                    //logger.debug("HS Frame is : \(rect)")
+
                     self._frame = frame
-                    
+
                     if calculateFromFrame {
                         var fs = false
                         for scr in NSScreen.screens where scr.frame == frame {
@@ -120,7 +139,7 @@ struct SizeHelper {
             return _frame.minY
         }
         
-        fileprivate func isFullscreen() -> Bool {
+        func isFullscreen() -> Bool {
             return fullscreen
         }
         

--- a/HSTracker/Logging/CoreManager.swift
+++ b/HSTracker/Logging/CoreManager.swift
@@ -410,6 +410,7 @@ final class CoreManager: NSObject {
     func appDeactivated(_ notification: Notification) {
         if let app = notification.userInfo!["NSWorkspaceApplicationKey"] as? NSRunningApplication {
 			if app.localizedName == CoreManager.applicationName {
+                NotificationCenter.default.post(name: Notification.Name(rawValue: Events.hearthstone_deactived), object: nil)
 				self.game.setHearthstoneActived(flag: false)
 			}
 			if app.bundleIdentifier == Bundle.main.bundleIdentifier {

--- a/HSTracker/Logging/Game.swift
+++ b/HSTracker/Logging/Game.swift
@@ -1437,8 +1437,10 @@ class Game: NSObject, PowerEventHandler {
             self.counter = 0
         } else if self.counter > 3 {
             let rect = SizeHelper.hearthstoneWindow.frame
+            // fullscreen-flag flips can leave _frame unchanged but still shift the 50px game-menu offset
+            let wasFullscreen = SizeHelper.hearthstoneWindow.isFullscreen()
             SizeHelper.hearthstoneWindow.reload()
-            if rect != SizeHelper.hearthstoneWindow.frame {
+            if rect != SizeHelper.hearthstoneWindow.frame || wasFullscreen != SizeHelper.hearthstoneWindow.isFullscreen() {
                 self.updateAllTrackers()
                 self.updateBattlegroundsOverlays()
                 self.updateConstructedMulliganOverlays()

--- a/HSTracker/Logging/Game.swift
+++ b/HSTracker/Logging/Game.swift
@@ -462,7 +462,7 @@ class Game: NSObject, PowerEventHandler {
             }
             
             if windowManager.playerActiveEffectsOverlay.visibility && windowManager.playerActiveEffectsOverlay.visibleEffects.count > 0 {
-                if hsActive {
+                if (Settings.hideAllWhenGameInBackground && hsActive) || !Settings.hideAllWhenGameInBackground {
                     windowManager.show(controller: windowManager.playerActiveEffectsOverlay, show: true, frame: SizeHelper.playerActiveEffectsFrame(), overlay: true)
                     windowManager.playerActiveEffectsOverlay.updateGrid()
                 } else {
@@ -471,7 +471,7 @@ class Game: NSObject, PowerEventHandler {
             }
 
             if windowManager.opponentActiveEffectsOverlay.visibility && windowManager.opponentActiveEffectsOverlay.visibleEffects.count > 0 {
-                if hsActive {
+                if (Settings.hideAllWhenGameInBackground && hsActive) || !Settings.hideAllWhenGameInBackground {
                     windowManager.show(controller: windowManager.opponentActiveEffectsOverlay, show: true, frame: SizeHelper.opponentActiveEffectsFrame(), overlay: true)
                     windowManager.opponentActiveEffectsOverlay.updateGrid()
                 } else {
@@ -495,7 +495,7 @@ class Game: NSObject, PowerEventHandler {
             }
             
             if windowManager.playerCountersOverlay.visibility && windowManager.playerCountersOverlay.visibleCounters.count > 0 {
-                if hsActive {
+                if (Settings.hideAllWhenGameInBackground && hsActive) || !Settings.hideAllWhenGameInBackground {
                     windowManager.show(controller: windowManager.playerCountersOverlay, show: true, frame: SizeHelper.playerCountersFrame(), overlay: true)
                     if windowManager.playerCountersOverlay.needsUpdate() {
                         DispatchQueue.main.async {
@@ -508,7 +508,7 @@ class Game: NSObject, PowerEventHandler {
             }
 
             if windowManager.opponentCountersOverlay.visibility && windowManager.opponentCountersOverlay.visibleCounters.count > 0 {
-                if hsActive {
+                if (Settings.hideAllWhenGameInBackground && hsActive) || !Settings.hideAllWhenGameInBackground {
                     windowManager.show(controller: windowManager.opponentCountersOverlay, show: true, frame: SizeHelper.opponentCountersFrame(), overlay: true)
                     if windowManager.opponentCountersOverlay.needsUpdate() {
                         DispatchQueue.main.async {
@@ -528,7 +528,7 @@ class Game: NSObject, PowerEventHandler {
             let hsActive = self.hearthstoneRunState.isActive
             
             if self.windowManager.constructedMulliganGuide.viewModel.visibility {
-                if hsActive {
+                if (Settings.hideAllWhenGameInBackground && hsActive) || !Settings.hideAllWhenGameInBackground {
                     self.windowManager.show(controller: self.windowManager.constructedMulliganGuide, show: true, frame: SizeHelper.hearthstoneWindow.frame, overlay: true)
                     DispatchQueue.main.async {
                         self.windowManager.constructedMulliganGuide.updateScaling()
@@ -537,9 +537,9 @@ class Game: NSObject, PowerEventHandler {
                     self.windowManager.show(controller: self.windowManager.constructedMulliganGuide, show: false)
                 }
             }
-            
+
             if self.windowManager.constructedMulliganGuidePreLobby.isVisible {
-                if hsActive && Settings.showMulliganGuidePreLobby {
+                if ((Settings.hideAllWhenGameInBackground && hsActive) || !Settings.hideAllWhenGameInBackground) && Settings.showMulliganGuidePreLobby {
                     self.windowManager.show(controller: self.windowManager.constructedMulliganGuidePreLobby, show: true, frame: SizeHelper.constructedMulliganGuidePreLobbyFrame(), overlay: true)
                     DispatchQueue.main.async {
                         self.windowManager.constructedMulliganGuidePreLobby.updateScaling()
@@ -560,14 +560,14 @@ class Game: NSObject, PowerEventHandler {
             let hsActive = hearthstoneRunState.isActive
 
             if let win =  windowManager.playerPlayerResourcesOverlay {
-                if hsActive && win.viewModel.visibility && shouldShowTracker {
+                if ((Settings.hideAllWhenGameInBackground && hsActive) || !Settings.hideAllWhenGameInBackground) && win.viewModel.visibility && shouldShowTracker {
                     windowManager.show(controller: win, show: true, frame: SizeHelper.playerMaxResourcesFrame(), overlay: true)
                 } else {
                     windowManager.show(controller: win, show: false)
                 }
             }
             if let win =  windowManager.opponentPlayerResourcesOverlay {
-                if hsActive && win.viewModel.visibility && shouldShowTracker {
+                if ((Settings.hideAllWhenGameInBackground && hsActive) || !Settings.hideAllWhenGameInBackground) && win.viewModel.visibility && shouldShowTracker {
                     windowManager.show(controller: win, show: true, frame: SizeHelper.opponentMaxResourcesFrame(), overlay: true)
                 } else {
                     windowManager.show(controller: win, show: false)
@@ -581,7 +581,7 @@ class Game: NSObject, PowerEventHandler {
             let hsActive = self.hearthstoneRunState.isActive
             
             if self.windowManager.battlegroundsSession.visibility {
-                if hsActive {
+                if (Settings.hideAllWhenGameInBackground && hsActive) || !Settings.hideAllWhenGameInBackground {
                     var rect = SizeHelper.battlegroundsSessionFrame()
                     if !Settings.autoPositionTrackers {
                         if let savedRect = Settings.battlegroundsSessionFrame {
@@ -596,7 +596,7 @@ class Game: NSObject, PowerEventHandler {
                 }
             }
             if self.windowManager.tier7PreLobby.isVisible {
-                if hsActive {
+                if (Settings.hideAllWhenGameInBackground && hsActive) || !Settings.hideAllWhenGameInBackground {
                     self.windowManager.show(controller: self.windowManager.tier7PreLobby, show: true, frame: SizeHelper.tier7PreLobbyFrame(), overlay: true)
                 } else {
                     self.windowManager.show(controller: self.windowManager.tier7PreLobby, show: false)
@@ -606,7 +606,7 @@ class Game: NSObject, PowerEventHandler {
             }
             
             if self.windowManager.battlegroundsHeroPicking.viewModel.visibility {
-                if hsActive {
+                if (Settings.hideAllWhenGameInBackground && hsActive) || !Settings.hideAllWhenGameInBackground {
                     self.windowManager.show(controller: self.windowManager.battlegroundsHeroPicking, show: true, frame: SizeHelper.hearthstoneWindow.frame, overlay: true)
                     DispatchQueue.main.async {
                         self.windowManager.battlegroundsHeroPicking.updateScaling()
@@ -617,7 +617,7 @@ class Game: NSObject, PowerEventHandler {
             }
             
             if self.windowManager.battlegroundsQuestPicking.viewModel.visibility {
-                if hsActive {
+                if (Settings.hideAllWhenGameInBackground && hsActive) || !Settings.hideAllWhenGameInBackground {
                     self.windowManager.show(controller: self.windowManager.battlegroundsQuestPicking, show: true, frame: SizeHelper.hearthstoneWindow.frame, overlay: true)
                     DispatchQueue.main.async {
                         self.windowManager.battlegroundsQuestPicking.updateScaling()
@@ -628,7 +628,7 @@ class Game: NSObject, PowerEventHandler {
             }
 
             if self.windowManager.battlegroundsTrinketPicking.viewModel.visibility {
-                if hsActive {
+                if (Settings.hideAllWhenGameInBackground && hsActive) || !Settings.hideAllWhenGameInBackground {
                     self.windowManager.show(controller: self.windowManager.battlegroundsTrinketPicking, show: true, frame: SizeHelper.hearthstoneWindow.frame, overlay: true)
                     DispatchQueue.main.async {
                         self.windowManager.battlegroundsTrinketPicking.updateScaling()
@@ -951,7 +951,7 @@ class Game: NSObject, PowerEventHandler {
     }
     
     func updateBattlegroundsSessionVisibility(_ isFriendsListOpen: Bool = false) {
-        let show = isRunning && hearthstoneRunState.isActive && Settings.showSessionRecap
+        let show = isRunning && ((Settings.hideAllWhenGameInBackground && hearthstoneRunState.isActive) || !Settings.hideAllWhenGameInBackground) && Settings.showSessionRecap
                 && (
                     (
                         // Scene is not transitioning

--- a/HSTracker/UIs/Battlegrounds/Session/BattlegroundsSession.swift
+++ b/HSTracker/UIs/Battlegrounds/Session/BattlegroundsSession.swift
@@ -448,6 +448,9 @@ class BattlegroundsSession: OverWindowController {
     }
 
     private func updateLatestGames() -> BattlegroundsLastGames.GameItem? {
+        let wm = AppDelegate.instance().coreManager.game.windowManager
+        wm.show(controller: wm.battlegroundsFinalBoard, show: false)
+
         sessionGames.removeAll()
         let sortedGames = BattlegroundsLastGames.instance.getPlayerGames(duos: isDuos).sorted(by: { (a, b) in a.startTime < b.startTime })
         deleteOldGames(games: sortedGames)

--- a/HSTracker/UIs/Toast/Toast.swift
+++ b/HSTracker/UIs/Toast/Toast.swift
@@ -167,15 +167,27 @@ class Toast {
             }
         }
         
+        override func mouseEntered(with event: NSEvent) {
+            guard action == nil, !SizeHelper.hearthstoneWindow.isFullscreen() else { return }
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0.2
+                animator().alphaValue = 0.3
+            }
+        }
+
+        override func mouseExited(with event: NSEvent) {
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0.2
+                animator().alphaValue = 1.0
+            }
+        }
+
         override func mouseDown(with event: NSEvent) {
-            guard self.action != nil else { return }
-            
             inClick = true
         }
         override func mouseUp(with event: NSEvent) {
-            guard self.action != nil else { return }
             guard inClick else { return }
-            
+
             inClick = false
             action?()
             toastWindow.remove(panel: self)

--- a/HSTracker/UIs/Toast/Toast.swift
+++ b/HSTracker/UIs/Toast/Toast.swift
@@ -18,7 +18,7 @@ class Toast {
         w.hasShadow = false
         w.acceptsMouseMovedEvents = true
         w.styleMask = .borderless
-        w.level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
+        w.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(CGWindowLevelKey.normalWindow)) + 1)
         w.backgroundColor = Color.clear
         
         w.orderFrontRegardless()

--- a/HSTracker/UIs/Trackers/WindowManager.swift
+++ b/HSTracker/UIs/Trackers/WindowManager.swift
@@ -436,11 +436,12 @@ class WindowManager {
                 }
             }
 
-            // set the level of the window : over all if hearthstone is active
-            // as a normal window otherwise
+            // Place overlays just above Hearthstone (normal level) but below
+            // any system UI level so macOS Notification Center, menu bar, and
+            // status items can render above them.
             let level: Int
             if overlay {
-                level = Int(CGShieldingWindowLevel())
+                level = Int(CGWindowLevelForKey(CGWindowLevelKey.normalWindow)) + 1
             } else {
                 level = Int(CGWindowLevelForKey(CGWindowLevelKey.normalWindow))
             }

--- a/HSTracker/UIs/Trackers/WindowManager.swift
+++ b/HSTracker/UIs/Trackers/WindowManager.swift
@@ -297,6 +297,7 @@ class WindowManager {
             self?.flavorText.window?.orderOut(nil)
             self?.playerActiveEffectsOverlay.window?.orderOut(nil)
             self?.opponentActiveEffectsOverlay.window?.orderOut(nil)
+            self?.tooltipGridCards.window?.orderOut(nil)
         }
     }
 


### PR DESCRIPTION
- fix: overlays no longer misplaced when activating HS via Mission Control
  Activating Hearthstone via Mission Control did not refresh the cached window frame, leaving overlays at stale coordinates. The Hearthstone window frame is now  reloaded on activation.

- fix: overlay windows no longer cover macOS Notification Center
  Overlay window level was above system UI, hiding the menu bar, status items, and Notification Center. Lowered to just above the normal window level so system UI renders above them.

- fix: final board window no longer lingers when session refreshes
  When the Battlegrounds Session view rebuilds its rows, a row removed mid-hover does not reliably receive a mouse-exit event, leaving the final-board popup orphaned. The popup is now dismissed before the rows are torn down.

- fix: overlays no longer linger when HS loses focus
  The deactivation handler updated the active flag but did not post a deactivation notification (its counterpart was posted on activation), so hide-on-background overlays only updated through the polling loop, with a delay of up to ~2.5 s. The notification is now posted on deactivation.

- fix: counter tooltip popup no longer lingers on game end
  The end-of-match cleanup omitted the counter tooltip window, so hovering a counter at the moment a match ended left the tooltip on screen. It is now included in the dismissal.

- fix: respect "hide when game in background" for more overlays
  Fourteen visibility checks gated solely on Hearthstone being active, ignoring the user's "hide all when game in background" preference. They now apply the same gate used by the other overlays so the preference is honored consistently.

- feat: toasts dim on hover and dismiss on click
  Non-actionable toasts now fade to 30% opacity on hover (excluded in fullscreen) so the content beneath remains visible. Click now dismisses any toast; previously only toasts with an action.
