### PR TITLE
fix: muradin last stand counter format crash

### DIFF
--- a/HSTracker/Hearthstone/CounterSystem/Counters/FriendlyAttacksThisGameCounter.swift
+++ b/HSTracker/Hearthstone/CounterSystem/Counters/FriendlyAttacksThisGameCounter.swift
@@ -32,7 +32,7 @@ class FriendlyAttacksThisGameCounter: NumericCounter {
     override func valueToShow() -> String {
         // C# uses Counter_AnimalCompanionCost as a generic localized string with a placeholder
         let remainingAttacks = max(9 - counter, 0)
-        return String(format: String.localizedString("Counter_MuradinLastStand", comment: ""), remainingAttacks)
+        return String(format: String.localizedString("Counter_MuradinLastStand", comment: ""), "\(remainingAttacks)")
     }
 
     override func handleTagChange(tag: GameTag, entity: Entity, value: Int, prevValue: Int) {


### PR DESCRIPTION
The Counter_MuradinLastStand localized string uses %@, but the Int argument is inferred as %lld by String(format:), causing a Foundation fault and crash when the counter renders. Wrap the value as a string to match the format specifier, consistent with AnimalCompanionCounter.

Regression introduced in 800245b4 ("fix: muradin last stand counter string").

  ## Test plan
  - [ ] Play a Standard match with Muradin's Last Stand in the deck and confirm the counter renders without crashing.