### PR TITLE
fix: normalize settings panes layout, text, and file structure

### DIFF
--- a/HSTracker.xcodeproj/project.pbxproj
+++ b/HSTracker.xcodeproj/project.pbxproj
@@ -292,7 +292,7 @@
 		43C1CA971E96CD6F008C20B1 /* InitialConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 439C7ED11C777FA900D29859 /* InitialConfiguration.swift */; };
 		43C1CA981E96CD6F008C20B1 /* Splashscreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 439C7ED31C777FA900D29859 /* Splashscreen.swift */; };
 		43C1CA991E96CD6F008C20B1 /* GeneralPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D308031C842DC000480488 /* GeneralPreferences.swift */; };
-		43C1CA9A1E96CD6F008C20B1 /* GamePrefences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D308051C842DC900480488 /* GamePrefences.swift */; };
+		43C1CA9A1E96CD6F008C20B1 /* GamePreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D308051C842DC900480488 /* GamePreferences.swift */; };
 		43C1CA9B1E96CD6F008C20B1 /* TrackersPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 437B5BC11CD2568100DE0A41 /* TrackersPreferences.swift */; };
 		43C1CA9C1E96CD6F008C20B1 /* PlayerTrackersPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D308071C84410000480488 /* PlayerTrackersPreferences.swift */; };
 		43C1CA9D1E96CD6F008C20B1 /* OpponentTrackersPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 437B5BB41CD2558500DE0A41 /* OpponentTrackersPreferences.swift */; };
@@ -337,7 +337,7 @@
 		43C568051D5E5BFF00451B6F /* UploadMetaData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C568041D5E5BFF00451B6F /* UploadMetaData.swift */; };
 		43D307FB1C83159C00480488 /* SizeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D307FA1C83159C00480488 /* SizeHelper.swift */; };
 		43D308041C842DC000480488 /* GeneralPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D308031C842DC000480488 /* GeneralPreferences.swift */; };
-		43D308061C842DC900480488 /* GamePrefences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D308051C842DC900480488 /* GamePrefences.swift */; };
+		43D308061C842DC900480488 /* GamePreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D308051C842DC900480488 /* GamePreferences.swift */; };
 		43D308081C84410000480488 /* PlayerTrackersPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D308071C84410000480488 /* PlayerTrackersPreferences.swift */; };
 		43E5C0041EB9152A00D49D8A /* HeroPower.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43F4D0481EB7A23D006B4479 /* HeroPower.swift */; };
 		43E77EE01C949C6D00C26950 /* TimerHud.xib in Resources */ = {isa = PBXBuildFile; fileRef = 43E77EDF1C949C6D00C26950 /* TimerHud.xib */; };
@@ -1779,7 +1779,7 @@
 		43C568041D5E5BFF00451B6F /* UploadMetaData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UploadMetaData.swift; sourceTree = "<group>"; };
 		43D307FA1C83159C00480488 /* SizeHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SizeHelper.swift; sourceTree = "<group>"; };
 		43D308031C842DC000480488 /* GeneralPreferences.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneralPreferences.swift; sourceTree = "<group>"; };
-		43D308051C842DC900480488 /* GamePrefences.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GamePrefences.swift; sourceTree = "<group>"; };
+		43D308051C842DC900480488 /* GamePreferences.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GamePreferences.swift; sourceTree = "<group>"; };
 		43D308071C84410000480488 /* PlayerTrackersPreferences.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlayerTrackersPreferences.swift; sourceTree = "<group>"; };
 		43E6632A1DC743BC007AB06E /* .travis.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = .travis.yml; sourceTree = "<group>"; };
 		43E77EDF1C949C6D00C26950 /* TimerHud.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TimerHud.xib; sourceTree = "<group>"; };
@@ -2168,7 +2168,7 @@
 		B8591FF72B24919F00B907A4 /* MulliganState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MulliganState.swift; sourceTree = "<group>"; };
 		B8591FF92B24F7C900B907A4 /* ObjectiveFactoryProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectiveFactoryProxy.swift; sourceTree = "<group>"; };
 		B8591FFB2B24F87C00B907A4 /* ObjectiveProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectiveProxy.swift; sourceTree = "<group>"; };
-		B85A0D52272CDDFB006D2648 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = HSTracker/UIs/Preferences/Base.lproj/MercenariesPreferences.xib; sourceTree = "<group>"; };
+		B85A0D52272CDDFB006D2648 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MercenariesPreferences.xib; sourceTree = "<group>"; };
 		B85A0D53272CDEFE006D2648 /* MercenariesPreferences.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MercenariesPreferences.swift; sourceTree = "<group>"; };
 		B85F1AC8258A558200A6F8C3 /* Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helper.swift; sourceTree = "<group>"; };
 		B8621F192746A785004DD0E9 /* Account.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Account.swift; sourceTree = "<group>"; };
@@ -2180,7 +2180,7 @@
 		B864AE232597BB0500793F36 /* AdventureConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdventureConfig.swift; sourceTree = "<group>"; };
 		B864AE262597DD9400793F36 /* GameSaveKeyId.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameSaveKeyId.swift; sourceTree = "<group>"; };
 		B864AE282599359400793F36 /* DeckType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeckType.swift; sourceTree = "<group>"; };
-		B864AE3925A4CC1200793F36 /* ImportingPreferences.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ImportingPreferences.xib; sourceTree = "<group>"; };
+		B864AE3B25A4CC1200793F36 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/ImportingPreferences.xib; sourceTree = "<group>"; };
 		B864AE3B25A4D15C00793F36 /* ImportingPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportingPreferences.swift; sourceTree = "<group>"; };
 		B86C9EAA27A17B3A00195C0A /* BrukanInvocationDeathrattles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrukanInvocationDeathrattles.swift; sourceTree = "<group>"; };
 		B86D89C12D95A04200AB65A5 /* FriendlyMinionsDiedThisGameCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendlyMinionsDiedThisGameCounter.swift; sourceTree = "<group>"; };
@@ -3085,7 +3085,7 @@
 				7BA4A8152FF3EA91000B3784 /* PreferencePaneController.swift */,
 				B8B7CC1E253C721400033758 /* BattlegroundsPreferences.swift */,
 				B8B7CC22253C74D100033758 /* BattlegroundsPreferences.xib */,
-				43D308051C842DC900480488 /* GamePrefences.swift */,
+				43D308051C842DC900480488 /* GamePreferences.swift */,
 				432B5FB81CB5372600B05D19 /* GamePreferences.xib */,
 				43D308031C842DC000480488 /* GeneralPreferences.swift */,
 				432B5FBB1CB5372C00B05D19 /* GeneralPreferences.xib */,
@@ -5594,7 +5594,7 @@
 				B89865C72D9201BC00BA5649 /* PitStop.swift in Sources */,
 				B846CC362E05F73200552F9C /* PhaseStalker.swift in Sources */,
 				B8196F142CC850BB007C0371 /* BaseCounter.swift in Sources */,
-				43D308061C842DC900480488 /* GamePrefences.swift in Sources */,
+				43D308061C842DC900480488 /* GamePreferences.swift in Sources */,
 				B8E1E5AA2D0B891F00383975 /* UndeadBuffCounter.swift in Sources */,
 				B8DC376125D06C2F00452A83 /* OpponentDeadForTracker.swift in Sources */,
 				43A8A0F71E1557C900AF34FD /* FormatType.swift in Sources */,
@@ -6613,7 +6613,7 @@
 				43C1CA971E96CD6F008C20B1 /* InitialConfiguration.swift in Sources */,
 				43C1CA981E96CD6F008C20B1 /* Splashscreen.swift in Sources */,
 				43C1CA991E96CD6F008C20B1 /* GeneralPreferences.swift in Sources */,
-				43C1CA9A1E96CD6F008C20B1 /* GamePrefences.swift in Sources */,
+				43C1CA9A1E96CD6F008C20B1 /* GamePreferences.swift in Sources */,
 				B804FC37294446ED00F74CD9 /* TextButton.swift in Sources */,
 				43C1CA9B1E96CD6F008C20B1 /* TrackersPreferences.swift in Sources */,
 				43C1CA9C1E96CD6F008C20B1 /* PlayerTrackersPreferences.swift in Sources */,
@@ -6679,6 +6679,14 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
+		B864AE3925A4CC1200793F36 /* ImportingPreferences.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				B864AE3B25A4CC1200793F36 /* Base */,
+			);
+			name = ImportingPreferences.xib;
+			sourceTree = "<group>";
+		};
 		432B5FAD1CB5351800B05D19 /* Localizable.strings */ = {
 			isa = PBXVariantGroup;
 			children = (

--- a/HSTracker/HSReplay/Base.lproj/HSReplayPreferences.xib
+++ b/HSTracker/HSReplay/Base.lproj/HSReplayPreferences.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23727" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24765" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23727"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24765"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -26,12 +26,12 @@
                 <outlet property="view" destination="aRU-mo-f3r" id="bxs-Qg-1OD"/>
             </connections>
         </customObject>
-        <stackView distribution="equalSpacing" orientation="vertical" alignment="leading" spacing="10" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" id="aRU-mo-f3r">
+        <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="10" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" id="aRU-mo-f3r">
             <rect key="frame" x="0.0" y="0.0" width="440" height="640"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="R7X-Vo-NSU">
-                    <rect key="frame" x="18" y="613" width="402" height="18"/>
+                    <rect key="frame" x="20" y="604" width="400" height="16"/>
                     <buttonCell key="cell" type="check" title="Show upload notification" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="a4D-nA-Vqz">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -41,7 +41,7 @@
                     </connections>
                 </button>
                 <button ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zU2-86-n1Q">
-                    <rect key="frame" x="18" y="567" width="422" height="18"/>
+                    <rect key="frame" x="20" y="578" width="420" height="16"/>
                     <buttonCell key="cell" type="check" title="Upload replays automatically" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="aAI-Yn-Z1P">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -51,13 +51,13 @@
                     </connections>
                 </button>
                 <box title="Upload game modes" translatesAutoresizingMaskIntoConstraints="NO" id="qvg-bJ-3rk">
-                    <rect key="frame" x="17" y="246" width="406" height="291"/>
+                    <rect key="frame" x="20" y="285" width="400" height="283"/>
                     <view key="contentView" id="ZEB-hT-h8U">
-                        <rect key="frame" x="4" y="5" width="398" height="270"/>
+                        <rect key="frame" x="0.0" y="0.0" width="400" height="270"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="crm-2T-nVp">
-                                <rect key="frame" x="18" y="243" width="360" height="18"/>
+                                <rect key="frame" x="10" y="244" width="380" height="16"/>
                                 <buttonCell key="cell" type="check" title="Ranked" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="hNI-pm-upP">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -67,7 +67,7 @@
                                 </connections>
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="4Xi-Zh-hUb">
-                                <rect key="frame" x="18" y="217" width="360" height="18"/>
+                                <rect key="frame" x="10" y="218" width="380" height="16"/>
                                 <buttonCell key="cell" type="check" title="Casual" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="zUq-Mn-Mae">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -77,7 +77,7 @@
                                 </connections>
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="dft-Ld-Kfh">
-                                <rect key="frame" x="18" y="191" width="360" height="18"/>
+                                <rect key="frame" x="10" y="192" width="380" height="16"/>
                                 <buttonCell key="cell" type="check" title="Arena" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="XLN-hm-TrI">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -87,7 +87,7 @@
                                 </connections>
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="iHo-eo-yaK">
-                                <rect key="frame" x="18" y="165" width="360" height="18"/>
+                                <rect key="frame" x="10" y="166" width="380" height="16"/>
                                 <buttonCell key="cell" type="check" title="Tavern Brawl" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="lGJ-41-bPm">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -97,7 +97,7 @@
                                 </connections>
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="ael-Gf-Yem">
-                                <rect key="frame" x="18" y="139" width="360" height="18"/>
+                                <rect key="frame" x="10" y="140" width="380" height="16"/>
                                 <buttonCell key="cell" type="check" title="Friendly" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Lla-JP-gmw">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -107,7 +107,7 @@
                                 </connections>
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="uEm-3o-LLY" userLabel="Adventure">
-                                <rect key="frame" x="18" y="113" width="360" height="18"/>
+                                <rect key="frame" x="10" y="114" width="380" height="16"/>
                                 <buttonCell key="cell" type="check" title="Adventure / Practice" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="XWA-c6-mjM">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -117,7 +117,7 @@
                                 </connections>
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="ysO-6y-8Kn">
-                                <rect key="frame" x="18" y="87" width="360" height="18"/>
+                                <rect key="frame" x="10" y="88" width="380" height="16"/>
                                 <buttonCell key="cell" type="check" title="Spectator" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="dX9-1S-Y1M">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -127,7 +127,7 @@
                                 </connections>
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="JJZ-kv-alD" userLabel="Battlegrounds">
-                                <rect key="frame" x="18" y="61" width="360" height="18"/>
+                                <rect key="frame" x="10" y="62" width="380" height="16"/>
                                 <buttonCell key="cell" type="check" title="Battlegrounds" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="ZRj-Jq-3gI" userLabel="Battlegrounds">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -137,7 +137,7 @@
                                 </connections>
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="Don-6f-aUb" userLabel="Duels">
-                                <rect key="frame" x="18" y="35" width="360" height="18"/>
+                                <rect key="frame" x="10" y="36" width="380" height="16"/>
                                 <buttonCell key="cell" type="check" title="Duels" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="3aJ-8X-AqP" userLabel="Duels">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -147,7 +147,7 @@
                                 </connections>
                             </button>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VVt-B2-3t1" userLabel="Mercenaries">
-                                <rect key="frame" x="18" y="9" width="360" height="18"/>
+                                <rect key="frame" x="10" y="10" width="380" height="16"/>
                                 <buttonCell key="cell" type="check" title="Mercenaries" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="9Sj-4I-EKw">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -158,52 +158,52 @@
                             </button>
                         </subviews>
                         <constraints>
-                            <constraint firstItem="dft-Ld-Kfh" firstAttribute="leading" secondItem="ZEB-hT-h8U" secondAttribute="leading" constant="20" id="1Zv-Pr-meM"/>
+                            <constraint firstItem="dft-Ld-Kfh" firstAttribute="leading" secondItem="ZEB-hT-h8U" secondAttribute="leading" constant="10" id="1Zv-Pr-meM"/>
                             <constraint firstItem="ael-Gf-Yem" firstAttribute="top" secondItem="iHo-eo-yaK" secondAttribute="bottom" constant="10" id="3h8-Wf-SIi"/>
-                            <constraint firstAttribute="trailing" secondItem="ael-Gf-Yem" secondAttribute="trailing" constant="20" id="5z6-Zb-pmE"/>
-                            <constraint firstAttribute="trailing" secondItem="JJZ-kv-alD" secondAttribute="trailing" constant="20" id="7Ub-HJ-RWW"/>
-                            <constraint firstItem="uEm-3o-LLY" firstAttribute="leading" secondItem="ZEB-hT-h8U" secondAttribute="leading" constant="20" id="9R9-d7-6hK"/>
-                            <constraint firstAttribute="trailing" secondItem="VVt-B2-3t1" secondAttribute="trailing" constant="20" id="9b8-ER-fnq"/>
-                            <constraint firstItem="ysO-6y-8Kn" firstAttribute="leading" secondItem="ZEB-hT-h8U" secondAttribute="leading" constant="20" id="Aw8-3N-z7K"/>
+                            <constraint firstAttribute="trailing" secondItem="ael-Gf-Yem" secondAttribute="trailing" constant="10" id="5z6-Zb-pmE"/>
+                            <constraint firstAttribute="trailing" secondItem="JJZ-kv-alD" secondAttribute="trailing" constant="10" id="7Ub-HJ-RWW"/>
+                            <constraint firstItem="uEm-3o-LLY" firstAttribute="leading" secondItem="ZEB-hT-h8U" secondAttribute="leading" constant="10" id="9R9-d7-6hK"/>
+                            <constraint firstAttribute="trailing" secondItem="VVt-B2-3t1" secondAttribute="trailing" constant="10" id="9b8-ER-fnq"/>
+                            <constraint firstItem="ysO-6y-8Kn" firstAttribute="leading" secondItem="ZEB-hT-h8U" secondAttribute="leading" constant="10" id="Aw8-3N-z7K"/>
                             <constraint firstItem="uEm-3o-LLY" firstAttribute="top" secondItem="ael-Gf-Yem" secondAttribute="bottom" constant="10" id="FEd-31-Slk"/>
-                            <constraint firstItem="4Xi-Zh-hUb" firstAttribute="leading" secondItem="ZEB-hT-h8U" secondAttribute="leading" constant="20" id="GX4-MM-YgF"/>
-                            <constraint firstAttribute="trailing" secondItem="4Xi-Zh-hUb" secondAttribute="trailing" constant="20" id="KlL-ND-mct"/>
-                            <constraint firstAttribute="trailing" secondItem="crm-2T-nVp" secondAttribute="trailing" constant="20" id="Ktf-eJ-AhU"/>
-                            <constraint firstAttribute="trailing" secondItem="Don-6f-aUb" secondAttribute="trailing" constant="20" id="Mce-0y-c0v"/>
+                            <constraint firstItem="4Xi-Zh-hUb" firstAttribute="leading" secondItem="ZEB-hT-h8U" secondAttribute="leading" constant="10" id="GX4-MM-YgF"/>
+                            <constraint firstAttribute="trailing" secondItem="4Xi-Zh-hUb" secondAttribute="trailing" constant="10" id="KlL-ND-mct"/>
+                            <constraint firstAttribute="trailing" secondItem="crm-2T-nVp" secondAttribute="trailing" constant="10" id="Ktf-eJ-AhU"/>
+                            <constraint firstAttribute="trailing" secondItem="Don-6f-aUb" secondAttribute="trailing" constant="10" id="Mce-0y-c0v"/>
                             <constraint firstItem="iHo-eo-yaK" firstAttribute="top" secondItem="dft-Ld-Kfh" secondAttribute="bottom" constant="10" id="YOn-ri-kZx"/>
-                            <constraint firstItem="crm-2T-nVp" firstAttribute="leading" secondItem="ZEB-hT-h8U" secondAttribute="leading" constant="20" id="Zow-bZ-GDb"/>
-                            <constraint firstItem="ael-Gf-Yem" firstAttribute="leading" secondItem="ZEB-hT-h8U" secondAttribute="leading" constant="20" id="aiM-uy-6m0"/>
-                            <constraint firstItem="JJZ-kv-alD" firstAttribute="leading" secondItem="ZEB-hT-h8U" secondAttribute="leading" constant="20" id="eVj-0b-VjB"/>
-                            <constraint firstItem="Don-6f-aUb" firstAttribute="leading" secondItem="ZEB-hT-h8U" secondAttribute="leading" constant="20" id="eqC-aT-XvN"/>
+                            <constraint firstItem="crm-2T-nVp" firstAttribute="leading" secondItem="ZEB-hT-h8U" secondAttribute="leading" constant="10" id="Zow-bZ-GDb"/>
+                            <constraint firstItem="ael-Gf-Yem" firstAttribute="leading" secondItem="ZEB-hT-h8U" secondAttribute="leading" constant="10" id="aiM-uy-6m0"/>
+                            <constraint firstItem="JJZ-kv-alD" firstAttribute="leading" secondItem="ZEB-hT-h8U" secondAttribute="leading" constant="10" id="eVj-0b-VjB"/>
+                            <constraint firstItem="Don-6f-aUb" firstAttribute="leading" secondItem="ZEB-hT-h8U" secondAttribute="leading" constant="10" id="eqC-aT-XvN"/>
                             <constraint firstItem="VVt-B2-3t1" firstAttribute="top" secondItem="Don-6f-aUb" secondAttribute="bottom" constant="10" id="erQ-U3-pQA"/>
                             <constraint firstItem="4Xi-Zh-hUb" firstAttribute="top" secondItem="crm-2T-nVp" secondAttribute="bottom" constant="10" id="fIf-MP-8d6"/>
-                            <constraint firstAttribute="trailing" secondItem="uEm-3o-LLY" secondAttribute="trailing" constant="20" id="fOr-x6-xm1"/>
+                            <constraint firstAttribute="trailing" secondItem="uEm-3o-LLY" secondAttribute="trailing" constant="10" id="fOr-x6-xm1"/>
                             <constraint firstAttribute="bottom" secondItem="VVt-B2-3t1" secondAttribute="bottom" constant="10" id="gL0-y0-mon"/>
                             <constraint firstItem="dft-Ld-Kfh" firstAttribute="top" secondItem="4Xi-Zh-hUb" secondAttribute="bottom" constant="10" id="gr0-6k-Lmx"/>
-                            <constraint firstItem="iHo-eo-yaK" firstAttribute="leading" secondItem="ZEB-hT-h8U" secondAttribute="leading" constant="20" id="hcF-Nv-yeo"/>
-                            <constraint firstItem="VVt-B2-3t1" firstAttribute="leading" secondItem="ZEB-hT-h8U" secondAttribute="leading" constant="20" id="hu6-az-6GL"/>
+                            <constraint firstItem="iHo-eo-yaK" firstAttribute="leading" secondItem="ZEB-hT-h8U" secondAttribute="leading" constant="10" id="hcF-Nv-yeo"/>
+                            <constraint firstItem="VVt-B2-3t1" firstAttribute="leading" secondItem="ZEB-hT-h8U" secondAttribute="leading" constant="10" id="hu6-az-6GL"/>
                             <constraint firstItem="crm-2T-nVp" firstAttribute="top" secondItem="ZEB-hT-h8U" secondAttribute="top" constant="10" id="k08-S1-MVj"/>
-                            <constraint firstAttribute="trailing" secondItem="dft-Ld-Kfh" secondAttribute="trailing" constant="20" id="uJE-tA-QKv"/>
+                            <constraint firstAttribute="trailing" secondItem="dft-Ld-Kfh" secondAttribute="trailing" constant="10" id="uJE-tA-QKv"/>
                             <constraint firstItem="JJZ-kv-alD" firstAttribute="top" secondItem="ysO-6y-8Kn" secondAttribute="bottom" constant="10" id="xuL-qf-kJ8"/>
-                            <constraint firstAttribute="trailing" secondItem="ysO-6y-8Kn" secondAttribute="trailing" constant="20" id="y4V-1e-OwJ"/>
+                            <constraint firstAttribute="trailing" secondItem="ysO-6y-8Kn" secondAttribute="trailing" constant="10" id="y4V-1e-OwJ"/>
                             <constraint firstItem="Don-6f-aUb" firstAttribute="top" secondItem="JJZ-kv-alD" secondAttribute="bottom" constant="10" id="yBX-H8-RqP"/>
                             <constraint firstItem="ysO-6y-8Kn" firstAttribute="top" secondItem="uEm-3o-LLY" secondAttribute="bottom" constant="10" id="yVB-Pe-zMS"/>
-                            <constraint firstAttribute="trailing" secondItem="iHo-eo-yaK" secondAttribute="trailing" constant="20" id="zPX-3T-bTe"/>
+                            <constraint firstAttribute="trailing" secondItem="iHo-eo-yaK" secondAttribute="trailing" constant="10" id="zPX-3T-bTe"/>
                         </constraints>
                     </view>
                     <font key="titleFont" metaFont="cellTitle"/>
                 </box>
                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="UbW-mX-Jca">
-                    <rect key="frame" x="0.0" y="217" width="440" height="5"/>
+                    <rect key="frame" x="0.0" y="272" width="440" height="5"/>
                 </box>
                 <box title="My Account" translatesAutoresizingMaskIntoConstraints="NO" id="KV0-Rl-jeI">
-                    <rect key="frame" x="17" y="84" width="406" height="104"/>
+                    <rect key="frame" x="20" y="164" width="400" height="100"/>
                     <view key="contentView" id="AhW-KI-qup">
-                        <rect key="frame" x="4" y="5" width="398" height="82"/>
+                        <rect key="frame" x="0.0" y="0.0" width="400" height="86"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="akc-iW-uso">
-                                <rect key="frame" x="13" y="45" width="372" height="32"/>
+                                <rect key="frame" x="10" y="52" width="380" height="24"/>
                                 <buttonCell key="cell" type="push" title="Login to HSReplay.net" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="87B-1e-y45">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -213,7 +213,7 @@
                                 </connections>
                             </button>
                             <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8vg-lb-UfO">
-                                <rect key="frame" x="18" y="10" width="362" height="32"/>
+                                <rect key="frame" x="8" y="10" width="384" height="32"/>
                                 <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Login to claim your replays and enable all HSReplay.net features." id="zQQ-GF-3Lg">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -222,22 +222,22 @@
                             </textField>
                         </subviews>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="akc-iW-uso" secondAttribute="trailing" constant="20" id="KTX-aC-FSm"/>
+                            <constraint firstAttribute="trailing" secondItem="akc-iW-uso" secondAttribute="trailing" constant="10" id="KTX-aC-FSm"/>
                             <constraint firstItem="akc-iW-uso" firstAttribute="top" secondItem="AhW-KI-qup" secondAttribute="top" constant="10" id="QHS-bf-F3F"/>
                             <constraint firstAttribute="bottom" secondItem="8vg-lb-UfO" secondAttribute="bottom" constant="10" id="Vm3-Hq-hAa"/>
                             <constraint firstItem="8vg-lb-UfO" firstAttribute="top" secondItem="akc-iW-uso" secondAttribute="bottom" constant="10" id="ZuD-4w-Y7d"/>
-                            <constraint firstItem="akc-iW-uso" firstAttribute="leading" secondItem="AhW-KI-qup" secondAttribute="leading" constant="20" id="bMd-le-8eh"/>
-                            <constraint firstItem="8vg-lb-UfO" firstAttribute="leading" secondItem="AhW-KI-qup" secondAttribute="leading" constant="20" id="p9D-4h-yX5"/>
-                            <constraint firstAttribute="trailing" secondItem="8vg-lb-UfO" secondAttribute="trailing" constant="20" id="zIW-Pa-2Kj"/>
+                            <constraint firstItem="akc-iW-uso" firstAttribute="leading" secondItem="AhW-KI-qup" secondAttribute="leading" constant="10" id="bMd-le-8eh"/>
+                            <constraint firstItem="8vg-lb-UfO" firstAttribute="leading" secondItem="AhW-KI-qup" secondAttribute="leading" constant="10" id="p9D-4h-yX5"/>
+                            <constraint firstAttribute="trailing" secondItem="8vg-lb-UfO" secondAttribute="trailing" constant="10" id="zIW-Pa-2Kj"/>
                         </constraints>
                     </view>
                     <font key="titleFont" metaFont="system"/>
                 </box>
                 <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pY7-IO-Y3U">
-                    <rect key="frame" x="20" y="10" width="400" height="48"/>
+                    <rect key="frame" x="20" y="20" width="400" height="134"/>
                     <subviews>
                         <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Cho-Aw-fPX">
-                            <rect key="frame" x="-2" y="32" width="13" height="16"/>
+                            <rect key="frame" x="-2" y="118" width="13" height="16"/>
                             <textFieldCell key="cell" lineBreakMode="clipping" title="X" id="fXm-MH-vJc">
                                 <font key="font" usesAppearanceFont="YES"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -249,7 +249,7 @@
                             </connections>
                         </textField>
                         <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LJN-bu-4T2">
-                            <rect key="frame" x="17" y="0.0" width="383" height="48"/>
+                            <rect key="frame" x="17" y="86" width="383" height="48"/>
                             <subviews>
                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jN5-VM-fr0">
                                     <rect key="frame" x="-2" y="32" width="122" height="16"/>
@@ -334,7 +334,7 @@
                     </customSpacing>
                 </stackView>
             </subviews>
-            <edgeInsets key="edgeInsets" left="0.0" right="0.0" top="10" bottom="10"/>
+            <edgeInsets key="edgeInsets" left="0.0" right="0.0" top="20" bottom="20"/>
             <constraints>
                 <constraint firstItem="qvg-bJ-3rk" firstAttribute="leading" secondItem="aRU-mo-f3r" secondAttribute="leading" constant="20" id="2bP-pn-8xm"/>
                 <constraint firstItem="pY7-IO-Y3U" firstAttribute="leading" secondItem="aRU-mo-f3r" secondAttribute="leading" constant="20" id="CPQ-3i-iiG"/>

--- a/HSTracker/UIs/Preferences/Base.lproj/BattlegroundsPreferences.xib
+++ b/HSTracker/UIs/Preferences/Base.lproj/BattlegroundsPreferences.xib
@@ -36,17 +36,15 @@
                 <outlet property="showTier7PreLobby" destination="0rS-5z-pRa" id="fhR-dD-W7g"/>
                 <outlet property="showTiers" destination="66r-fs-Jja" id="g6P-yg-2Du"/>
                 <outlet property="showTurnCounter" destination="led-ON-LPz" id="hz4-bl-Hks"/>
-                <outlet property="view" destination="c22-O7-iKe" id="rY0-tu-oVL"/>
+                <outlet property="view" destination="PgR-kc-NQ2" id="rY0-tu-oVL"/>
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="c22-O7-iKe">
+        <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="10" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" id="PgR-kc-NQ2">
             <rect key="frame" x="0.0" y="0.0" width="414" height="848"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="10" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PgR-kc-NQ2">
-                    <rect key="frame" x="0.0" y="0.0" width="414" height="848"/>
-                    <subviews>
                         <box title="Tier7" translatesAutoresizingMaskIntoConstraints="NO" id="kdX-CA-zhQ">
                             <rect key="frame" x="7" y="642" width="400" height="186"/>
                             <view key="contentView" id="FaQ-JU-XUN">
@@ -58,7 +56,7 @@
                                         <subviews>
                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3Ts-2S-wmU">
                                                 <rect key="frame" x="-2" y="139" width="151" height="18"/>
-                                                <buttonCell key="cell" type="check" title="Enable Tier7 Overlay" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="fts-jC-w9N">
+                                                <buttonCell key="cell" type="check" title="Enable Tier7 overlay" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="fts-jC-w9N">
                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                     <font key="font" metaFont="system"/>
                                                 </buttonCell>
@@ -68,7 +66,7 @@
                                             </button>
                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0rS-5z-pRa">
                                                 <rect key="frame" x="-2" y="113" width="272" height="18"/>
-                                                <buttonCell key="cell" type="check" title="Show Tier7 menu Overlay (MMR &amp; Stats)" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Xmc-n4-oyS">
+                                                <buttonCell key="cell" type="check" title="Show Tier7 menu overlay (MMR &amp; stats)" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Xmc-n4-oyS">
                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                     <font key="font" metaFont="system"/>
                                                 </buttonCell>
@@ -78,7 +76,7 @@
                                             </button>
                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bM5-OJ-VEP">
                                                 <rect key="frame" x="-2" y="87" width="264" height="18"/>
-                                                <buttonCell key="cell" type="check" title="Show Battlegrounds Hero Picking Stats" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="gkM-fC-BN7">
+                                                <buttonCell key="cell" type="check" title="Show Battlegrounds hero picking stats" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="gkM-fC-BN7">
                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                     <font key="font" metaFont="system"/>
                                                 </buttonCell>
@@ -88,7 +86,7 @@
                                             </button>
                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QeJ-mI-bjv">
                                                 <rect key="frame" x="-2" y="61" width="270" height="18"/>
-                                                <buttonCell key="cell" type="check" title="Show Battlegrounds Quest Picking Stats" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="po8-Pv-EE8">
+                                                <buttonCell key="cell" type="check" title="Show Battlegrounds quest picking stats" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="po8-Pv-EE8">
                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                     <font key="font" metaFont="system"/>
                                                 </buttonCell>
@@ -98,7 +96,7 @@
                                             </button>
                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="k99-WS-d2I">
                                                 <rect key="frame" x="-2" y="35" width="185" height="18"/>
-                                                <buttonCell key="cell" type="check" title="Show Trinket picking stats" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="be4-8p-MhH">
+                                                <buttonCell key="cell" type="check" title="Show trinket picking stats" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="be4-8p-MhH">
                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                     <font key="font" metaFont="system"/>
                                                 </buttonCell>
@@ -108,7 +106,7 @@
                                             </button>
                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WNs-L3-3NJ">
                                                 <rect key="frame" x="-2" y="9" width="243" height="18"/>
-                                                <buttonCell key="cell" type="check" title="Show Comp stats (in session recap)" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="tBZ-Tg-1hx">
+                                                <buttonCell key="cell" type="check" title="Show comp stats (in session recap)" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="tBZ-Tg-1hx">
                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                     <font key="font" metaFont="system"/>
                                                 </buttonCell>
@@ -247,7 +245,7 @@
                         </button>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="nIZ-ZN-jaR">
                             <rect key="frame" x="8" y="375" width="185" height="18"/>
-                            <buttonCell key="cell" type="check" title="Always show Tavern Tier 7" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="EaL-aA-A3g">
+                            <buttonCell key="cell" type="check" title="Always show tavern tier 7" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="EaL-aA-A3g">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                 <font key="font" metaFont="system"/>
                             </buttonCell>
@@ -257,7 +255,7 @@
                         </button>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3HM-F3-XZP">
                             <rect key="frame" x="8" y="349" width="262" height="18"/>
-                            <buttonCell key="cell" type="check" title="Show battlecry and deathrattle on tiers" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="dcW-bJ-e6v">
+                            <buttonCell key="cell" type="check" title="Show Battlecry and Deathrattle on tiers" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="dcW-bJ-e6v">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                 <font key="font" metaFont="system"/>
                             </buttonCell>
@@ -267,7 +265,7 @@
                         </button>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wJz-9K-13G">
                             <rect key="frame" x="8" y="323" width="142" height="18"/>
-                            <buttonCell key="cell" type="check" title="Show Tavern spells" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="QUp-Tx-AlQ">
+                            <buttonCell key="cell" type="check" title="Show tavern spells" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="QUp-Tx-AlQ">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                 <font key="font" metaFont="system"/>
                             </buttonCell>
@@ -287,7 +285,7 @@
                         </button>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aHt-pi-28x" userLabel="Show hero comparison">
                             <rect key="frame" x="8" y="271" width="168" height="18"/>
-                            <buttonCell key="cell" type="check" title="Show hero comparision" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="oXq-kH-uaV">
+                            <buttonCell key="cell" type="check" title="Show hero comparison" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="oXq-kH-uaV">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                 <font key="font" metaFont="system"/>
                             </buttonCell>
@@ -506,12 +504,12 @@
                             </view>
                         </box>
                     </subviews>
-                    <edgeInsets key="edgeInsets" left="10" right="10" top="20" bottom="20"/>
+                    <edgeInsets key="edgeInsets" left="20" right="20" top="20" bottom="20"/>
                     <constraints>
-                        <constraint firstAttribute="trailing" secondItem="JUT-jb-jLx" secondAttribute="trailing" constant="10" id="9Ne-eL-PRV"/>
-                        <constraint firstItem="JUT-jb-jLx" firstAttribute="leading" secondItem="PgR-kc-NQ2" secondAttribute="leading" constant="10" id="ZUD-U1-Azp"/>
-                        <constraint firstAttribute="trailing" secondItem="9TS-9T-RQV" secondAttribute="trailing" constant="10" id="pEH-0P-fUo"/>
-                        <constraint firstAttribute="trailing" secondItem="kdX-CA-zhQ" secondAttribute="trailing" constant="10" id="yl6-uH-FNx"/>
+                        <constraint firstAttribute="trailing" secondItem="JUT-jb-jLx" secondAttribute="trailing" constant="20" id="9Ne-eL-PRV"/>
+                        <constraint firstItem="JUT-jb-jLx" firstAttribute="leading" secondItem="PgR-kc-NQ2" secondAttribute="leading" constant="20" id="ZUD-U1-Azp"/>
+                        <constraint firstAttribute="trailing" secondItem="9TS-9T-RQV" secondAttribute="trailing" constant="20" id="pEH-0P-fUo"/>
+                        <constraint firstAttribute="trailing" secondItem="kdX-CA-zhQ" secondAttribute="trailing" constant="20" id="yl6-uH-FNx"/>
                     </constraints>
                     <visibilityPriorities>
                         <integer value="1000"/>
@@ -541,15 +539,7 @@
                         <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>
                     </customSpacing>
+                    <point key="canvasLocation" x="-167" y="62.5"/>
                 </stackView>
-            </subviews>
-            <constraints>
-                <constraint firstItem="PgR-kc-NQ2" firstAttribute="top" secondItem="c22-O7-iKe" secondAttribute="top" id="PKM-mW-KbX"/>
-                <constraint firstAttribute="bottom" secondItem="PgR-kc-NQ2" secondAttribute="bottom" id="Szj-RU-H3P"/>
-                <constraint firstAttribute="trailing" secondItem="PgR-kc-NQ2" secondAttribute="trailing" id="U3X-NU-WdV"/>
-                <constraint firstItem="PgR-kc-NQ2" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" id="qHs-Ko-xIt"/>
-            </constraints>
-            <point key="canvasLocation" x="-167" y="62.5"/>
-        </customView>
     </objects>
 </document>

--- a/HSTracker/UIs/Preferences/Base.lproj/GamePreferences.xib
+++ b/HSTracker/UIs/Preferences/Base.lproj/GamePreferences.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24765" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24765"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -20,91 +20,135 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="c22-O7-iKe">
-            <rect key="frame" x="0.0" y="0.0" width="515" height="160"/>
+        <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="10" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" id="c22-O7-iKe">
+            <rect key="frame" x="0.0" y="0.0" width="467" height="194"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ya6-7I-GEB">
-                    <rect key="frame" x="8" y="124" width="180" height="16"/>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Hearthstone directory" id="s5e-Q8-cm8">
-                        <font key="font" metaFont="system"/>
-                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
-                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="O8a-FA-pQF">
-                    <rect key="frame" x="196" y="122" width="200" height="21"/>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="200" id="EsH-tL-QRX"/>
-                    </constraints>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="mVt-NV-jCc">
-                        <font key="font" metaFont="system"/>
-                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
-                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="btV-TN-8Ol">
-                    <rect key="frame" x="394" y="115" width="81" height="32"/>
-                    <buttonCell key="cell" type="push" title="Choose" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="L10-Eu-Nrc">
-                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
-                    </buttonCell>
-                    <connections>
-                        <action selector="choosePath:" target="-2" id="Lwp-b3-mc5"/>
-                    </connections>
-                </button>
-                <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="uK7-xp-tnR">
-                    <rect key="frame" x="473" y="116" width="32" height="32"/>
-                    <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="check" id="EgB-xn-1K7"/>
-                </imageView>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HgM-aY-crX">
-                    <rect key="frame" x="8" y="98" width="239" height="16"/>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="HSTracker language" id="r3b-jQ-tUY">
-                        <font key="font" metaFont="system"/>
-                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
-                <comboBox verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7in-D6-SFv">
-                    <rect key="frame" x="254" y="94" width="254" height="23"/>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="250" id="nKM-SX-NFV"/>
-                    </constraints>
-                    <comboBoxCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" completes="NO" usesDataSource="YES" numberOfVisibleItems="5" id="wdm-gt-Ui9">
-                        <font key="font" metaFont="system"/>
-                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                    </comboBoxCell>
-                    <connections>
-                        <outlet property="dataSource" destination="-2" id="LOX-49-0uB"/>
-                        <outlet property="delegate" destination="-2" id="gwc-RI-C6C"/>
-                    </connections>
-                </comboBox>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="SP4-ge-wIF">
-                    <rect key="frame" x="8" y="72" width="239" height="16"/>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Hearthstone language" id="biS-yx-frk">
-                        <font key="font" metaFont="system"/>
-                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
-                <comboBox verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aGA-sR-AWM">
-                    <rect key="frame" x="254" y="68" width="254" height="23"/>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="250" id="QVQ-aE-qm7"/>
-                    </constraints>
-                    <comboBoxCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" completes="NO" usesDataSource="YES" numberOfVisibleItems="5" id="v4t-e0-PdC">
-                        <font key="font" metaFont="system"/>
-                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                    </comboBoxCell>
-                    <connections>
-                        <outlet property="dataSource" destination="-2" id="dAL-B0-OHZ"/>
-                        <outlet property="delegate" destination="-2" id="ix1-p5-i6H"/>
-                    </connections>
-                </comboBox>
-                <button translatesAutoresizingMaskIntoConstraints="NO" id="Tn5-ef-XSB">
-                    <rect key="frame" x="8" y="45" width="497" height="18"/>
-                    <buttonCell key="cell" type="check" title="Auto archive arena deck on run end" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="hMe-FU-CjR">
+                <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gm1-row-pth" userLabel="PathRow">
+                    <rect key="frame" x="20" y="142" width="427" height="32"/>
+                    <subviews>
+                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ya6-7I-GEB">
+                            <rect key="frame" x="-2" y="8" width="137" height="16"/>
+                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Hearthstone directory" id="s5e-Q8-cm8">
+                                <font key="font" metaFont="system"/>
+                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                            </textFieldCell>
+                        </textField>
+                        <textField focusRingType="none" horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="O8a-FA-pQF">
+                            <rect key="frame" x="141" y="4" width="176" height="24"/>
+                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="mVt-NV-jCc">
+                                <font key="font" metaFont="system"/>
+                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                            </textFieldCell>
+                        </textField>
+                        <button horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="btV-TN-8Ol">
+                            <rect key="frame" x="325" y="4" width="70" height="24"/>
+                            <buttonCell key="cell" type="push" title="Choose" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="L10-Eu-Nrc">
+                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                <font key="font" metaFont="system"/>
+                            </buttonCell>
+                            <connections>
+                                <action selector="choosePath:" target="-2" id="Lwp-b3-mc5"/>
+                            </connections>
+                        </button>
+                        <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="uK7-xp-tnR">
+                            <rect key="frame" x="403" y="0.0" width="24" height="32"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="24" id="uK7-wd-24w"/>
+                            </constraints>
+                            <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="check" id="EgB-xn-1K7"/>
+                        </imageView>
+                    </subviews>
+                    <visibilityPriorities>
+                        <integer value="1000"/>
+                        <integer value="1000"/>
+                        <integer value="1000"/>
+                        <integer value="1000"/>
+                    </visibilityPriorities>
+                    <customSpacing>
+                        <real value="3.4028234663852886e+38"/>
+                        <real value="3.4028234663852886e+38"/>
+                        <real value="3.4028234663852886e+38"/>
+                        <real value="3.4028234663852886e+38"/>
+                    </customSpacing>
+                </stackView>
+                <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" ambiguous="YES" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gm2-row-hst" userLabel="HSTrackerLanguageRow">
+                    <rect key="frame" x="20" y="106" width="427" height="26"/>
+                    <subviews>
+                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HgM-aY-crX">
+                            <rect key="frame" x="-2" y="5" width="173" height="16"/>
+                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="HSTracker language" id="r3b-jQ-tUY">
+                                <font key="font" metaFont="system"/>
+                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                            </textFieldCell>
+                        </textField>
+                        <comboBox focusRingType="none" horizontalHuggingPriority="249" verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7in-D6-SFv">
+                            <rect key="frame" x="177" y="1" width="250" height="24"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="250" id="nKM-SX-NFV"/>
+                            </constraints>
+                            <comboBoxCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" completes="NO" usesDataSource="YES" numberOfVisibleItems="5" id="wdm-gt-Ui9">
+                                <font key="font" metaFont="system"/>
+                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                            </comboBoxCell>
+                            <connections>
+                                <outlet property="dataSource" destination="-2" id="LOX-49-0uB"/>
+                                <outlet property="delegate" destination="-2" id="gwc-RI-C6C"/>
+                            </connections>
+                        </comboBox>
+                    </subviews>
+                    <visibilityPriorities>
+                        <integer value="1000"/>
+                        <integer value="1000"/>
+                    </visibilityPriorities>
+                    <customSpacing>
+                        <real value="3.4028234663852886e+38"/>
+                        <real value="3.4028234663852886e+38"/>
+                    </customSpacing>
+                </stackView>
+                <stackView distribution="fill" orientation="horizontal" alignment="firstBaseline" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" ambiguous="YES" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gm3-row-hs" userLabel="HearthstoneLanguageRow">
+                    <rect key="frame" x="20" y="72" width="427" height="24"/>
+                    <subviews>
+                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="SP4-ge-wIF">
+                            <rect key="frame" x="-2" y="7" width="173" height="16"/>
+                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Hearthstone language" id="biS-yx-frk">
+                                <font key="font" metaFont="system"/>
+                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                            </textFieldCell>
+                        </textField>
+                        <comboBox focusRingType="none" horizontalHuggingPriority="249" verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aGA-sR-AWM">
+                            <rect key="frame" x="177" y="0.0" width="250" height="24"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="250" id="QVQ-aE-qm7"/>
+                            </constraints>
+                            <comboBoxCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" completes="NO" usesDataSource="YES" numberOfVisibleItems="5" id="v4t-e0-PdC">
+                                <font key="font" metaFont="system"/>
+                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                            </comboBoxCell>
+                            <connections>
+                                <outlet property="dataSource" destination="-2" id="dAL-B0-OHZ"/>
+                                <outlet property="delegate" destination="-2" id="ix1-p5-i6H"/>
+                            </connections>
+                        </comboBox>
+                    </subviews>
+                    <visibilityPriorities>
+                        <integer value="1000"/>
+                        <integer value="1000"/>
+                    </visibilityPriorities>
+                    <customSpacing>
+                        <real value="3.4028234663852886e+38"/>
+                        <real value="3.4028234663852886e+38"/>
+                    </customSpacing>
+                </stackView>
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Tn5-ef-XSB">
+                    <rect key="frame" x="20" y="46" width="427" height="16"/>
+                    <buttonCell key="cell" type="check" title="Auto archive Arena deck on run end" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="hMe-FU-CjR">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
@@ -112,8 +156,8 @@
                         <action selector="checkboxClicked:" target="-2" id="a1y-Ip-M7o"/>
                     </connections>
                 </button>
-                <button translatesAutoresizingMaskIntoConstraints="NO" id="2mA-uh-1cv">
-                    <rect key="frame" x="8" y="19" width="497" height="18"/>
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2mA-uh-1cv">
+                    <rect key="frame" x="20" y="20" width="427" height="16"/>
                     <buttonCell key="cell" type="check" title="Auto import and select decks" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="mhj-j8-OPU">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -123,36 +167,35 @@
                     </connections>
                 </button>
             </subviews>
+            <edgeInsets key="edgeInsets" left="20" right="20" top="20" bottom="20"/>
             <constraints>
-                <constraint firstItem="O8a-FA-pQF" firstAttribute="leading" secondItem="ya6-7I-GEB" secondAttribute="trailing" constant="10" id="1PI-RP-3Na"/>
-                <constraint firstItem="SP4-ge-wIF" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="10" id="2ff-PM-VaH"/>
-                <constraint firstItem="Tn5-ef-XSB" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="10" id="3lM-5K-aAe"/>
-                <constraint firstItem="7in-D6-SFv" firstAttribute="leading" secondItem="HgM-aY-crX" secondAttribute="trailing" constant="10" id="4sK-Hn-kMT"/>
-                <constraint firstItem="2mA-uh-1cv" firstAttribute="top" secondItem="Tn5-ef-XSB" secondAttribute="bottom" constant="10" id="5nc-Ss-MSD"/>
-                <constraint firstItem="aGA-sR-AWM" firstAttribute="leading" secondItem="SP4-ge-wIF" secondAttribute="trailing" constant="10" id="88G-9b-9kA"/>
-                <constraint firstAttribute="trailing" secondItem="aGA-sR-AWM" secondAttribute="trailing" constant="10" id="Awr-5G-QhE"/>
-                <constraint firstItem="uK7-xp-tnR" firstAttribute="leading" secondItem="btV-TN-8Ol" secondAttribute="trailing" constant="5" id="Frb-kQ-sRY"/>
-                <constraint firstItem="Tn5-ef-XSB" firstAttribute="top" secondItem="SP4-ge-wIF" secondAttribute="bottom" constant="10" id="KPt-O9-P0N"/>
-                <constraint firstItem="btV-TN-8Ol" firstAttribute="centerY" secondItem="O8a-FA-pQF" secondAttribute="centerY" id="MUK-Cg-gJ7"/>
-                <constraint firstItem="ya6-7I-GEB" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="10" id="TVO-GP-7CE"/>
-                <constraint firstItem="uK7-xp-tnR" firstAttribute="centerY" secondItem="btV-TN-8Ol" secondAttribute="centerY" id="X3E-nX-5mA"/>
-                <constraint firstAttribute="trailing" secondItem="2mA-uh-1cv" secondAttribute="trailing" constant="10" id="YdO-7v-hgc"/>
-                <constraint firstItem="ya6-7I-GEB" firstAttribute="top" secondItem="c22-O7-iKe" secondAttribute="top" constant="20" id="Zck-pY-WhC"/>
-                <constraint firstAttribute="bottom" secondItem="2mA-uh-1cv" secondAttribute="bottom" constant="20" id="bpV-fn-niI"/>
-                <constraint firstAttribute="trailing" secondItem="7in-D6-SFv" secondAttribute="trailing" constant="10" id="fZf-Tc-L6e"/>
-                <constraint firstItem="HgM-aY-crX" firstAttribute="top" secondItem="ya6-7I-GEB" secondAttribute="bottom" constant="10" id="giG-hE-NV7"/>
-                <constraint firstAttribute="trailing" secondItem="Tn5-ef-XSB" secondAttribute="trailing" constant="10" id="jud-eq-Iyk"/>
-                <constraint firstItem="SP4-ge-wIF" firstAttribute="top" secondItem="HgM-aY-crX" secondAttribute="bottom" constant="10" id="m5B-iK-6Da"/>
-                <constraint firstItem="HgM-aY-crX" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="10" id="n1C-h0-el7"/>
-                <constraint firstItem="O8a-FA-pQF" firstAttribute="centerY" secondItem="ya6-7I-GEB" secondAttribute="centerY" id="sU7-AM-iKk"/>
-                <constraint firstItem="7in-D6-SFv" firstAttribute="centerY" secondItem="HgM-aY-crX" secondAttribute="centerY" id="sl6-Tg-WAR"/>
-                <constraint firstItem="2mA-uh-1cv" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="10" id="vRI-7T-6d9"/>
-                <constraint firstItem="aGA-sR-AWM" firstAttribute="centerY" secondItem="SP4-ge-wIF" secondAttribute="centerY" id="wEb-PL-UPa"/>
-                <constraint firstItem="btV-TN-8Ol" firstAttribute="leading" secondItem="O8a-FA-pQF" secondAttribute="trailing" constant="5" id="yfO-lk-no5"/>
-                <constraint firstAttribute="trailing" secondItem="uK7-xp-tnR" secondAttribute="trailing" constant="10" id="zQa-Cd-tp4"/>
+                <constraint firstItem="gm1-row-pth" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="20" symbolic="YES" id="gm-l0-pth"/>
+                <constraint firstItem="gm2-row-hst" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="20" symbolic="YES" id="gm-l1-hst"/>
+                <constraint firstItem="gm3-row-hs" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="20" symbolic="YES" id="gm-l2-hs"/>
+                <constraint firstItem="Tn5-ef-XSB" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="20" symbolic="YES" id="gm-l3-Tn5"/>
+                <constraint firstItem="2mA-uh-1cv" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="20" symbolic="YES" id="gm-l4-2mA"/>
+                <constraint firstAttribute="trailing" secondItem="gm1-row-pth" secondAttribute="trailing" constant="20" symbolic="YES" id="gm-t0-pth"/>
+                <constraint firstAttribute="trailing" secondItem="gm2-row-hst" secondAttribute="trailing" constant="20" symbolic="YES" id="gm-t1-hst"/>
+                <constraint firstAttribute="trailing" secondItem="gm3-row-hs" secondAttribute="trailing" constant="20" symbolic="YES" id="gm-t2-hs"/>
+                <constraint firstAttribute="trailing" secondItem="Tn5-ef-XSB" secondAttribute="trailing" constant="20" symbolic="YES" id="gm-t3-Tn5"/>
+                <constraint firstAttribute="trailing" secondItem="2mA-uh-1cv" secondAttribute="trailing" constant="20" symbolic="YES" id="gm-t4-2mA"/>
             </constraints>
+            <visibilityPriorities>
+                <integer value="1000"/>
+                <integer value="1000"/>
+                <integer value="1000"/>
+                <integer value="1000"/>
+                <integer value="1000"/>
+            </visibilityPriorities>
+            <customSpacing>
+                <real value="3.4028234663852886e+38"/>
+                <real value="3.4028234663852886e+38"/>
+                <real value="3.4028234663852886e+38"/>
+                <real value="3.4028234663852886e+38"/>
+                <real value="3.4028234663852886e+38"/>
+            </customSpacing>
             <point key="canvasLocation" x="493.5" y="242"/>
-        </customView>
+        </stackView>
     </objects>
     <resources>
         <image name="check" width="32" height="32"/>

--- a/HSTracker/UIs/Preferences/Base.lproj/GeneralPreferences.xib
+++ b/HSTracker/UIs/Preferences/Base.lproj/GeneralPreferences.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24765" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22689"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24765"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -21,11 +21,12 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="c22-O7-iKe">
-            <rect key="frame" x="0.0" y="0.0" width="480" height="238"/>
+        <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="10" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" id="c22-O7-iKe">
+            <rect key="frame" x="0.0" y="0.0" width="460" height="238"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <button toolTip="Notifications are only visible if Hearthstone is not focused" translatesAutoresizingMaskIntoConstraints="NO" id="08B-rI-8LA">
-                    <rect key="frame" x="8" y="201" width="462" height="18"/>
+                <button toolTip="Notifications are only visible if Hearthstone is not focused" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="08B-rI-8LA">
+                    <rect key="frame" x="20" y="202" width="420" height="16"/>
                     <buttonCell key="cell" type="check" title="Notify me when the game starts" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="aaX-mu-c31">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -34,8 +35,8 @@
                         <action selector="checkboxClicked:" target="-2" id="hNr-19-7kI"/>
                     </connections>
                 </button>
-                <button toolTip="Notifications are only visible if Hearthstone is not focused" translatesAutoresizingMaskIntoConstraints="NO" id="c8y-VJ-p2U">
-                    <rect key="frame" x="8" y="175" width="462" height="18"/>
+                <button toolTip="Notifications are only visible if Hearthstone is not focused" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="c8y-VJ-p2U">
+                    <rect key="frame" x="20" y="176" width="420" height="16"/>
                     <buttonCell key="cell" type="check" title="Notify me when my turn starts" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Rbw-dw-oAI">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -44,8 +45,8 @@
                         <action selector="checkboxClicked:" target="-2" id="sNx-TF-pXv"/>
                     </connections>
                 </button>
-                <button toolTip="Notifications are only visible if Hearthstone is not focused" translatesAutoresizingMaskIntoConstraints="NO" id="Yit-xi-gbj">
-                    <rect key="frame" x="8" y="149" width="462" height="18"/>
+                <button toolTip="Notifications are only visible if Hearthstone is not focused" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Yit-xi-gbj">
+                    <rect key="frame" x="20" y="150" width="420" height="16"/>
                     <buttonCell key="cell" type="check" title="Notify me when my opponent concedes" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="GhP-a6-Faw">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -54,8 +55,8 @@
                         <action selector="checkboxClicked:" target="-2" id="qk1-TT-zH6"/>
                     </connections>
                 </button>
-                <button toolTip="Notifications are only visible if Hearthstone is not focused" translatesAutoresizingMaskIntoConstraints="NO" id="hzK-vu-1RX">
-                    <rect key="frame" x="8" y="123" width="462" height="18"/>
+                <button toolTip="Notifications are only visible if Hearthstone is not focused" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hzK-vu-1RX">
+                    <rect key="frame" x="20" y="124" width="420" height="16"/>
                     <buttonCell key="cell" type="check" title="Close HSTracker when Hearthstone closes" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="oQm-3D-WOn">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -64,8 +65,8 @@
                         <action selector="checkboxClicked:" target="-2" id="Ghf-Xb-5un"/>
                     </connections>
                 </button>
-                <button translatesAutoresizingMaskIntoConstraints="NO" id="lku-8T-sZE">
-                    <rect key="frame" x="8" y="97" width="462" height="18"/>
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lku-8T-sZE">
+                    <rect key="frame" x="20" y="98" width="420" height="16"/>
                     <buttonCell key="cell" type="check" title="Save replays" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="vod-AA-O2m">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -74,9 +75,9 @@
                         <action selector="checkboxClicked:" target="-2" id="9fs-Sq-3TA"/>
                     </connections>
                 </button>
-                <button translatesAutoresizingMaskIntoConstraints="NO" id="9ux-qy-79X">
-                    <rect key="frame" x="8" y="71" width="462" height="18"/>
-                    <buttonCell key="cell" type="check" title="Enable Apphealth icon badge" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="mBv-nX-Cn3">
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9ux-qy-79X">
+                    <rect key="frame" x="20" y="72" width="420" height="16"/>
+                    <buttonCell key="cell" type="check" title="Enable AppHealth icon badge" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="mBv-nX-Cn3">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
@@ -84,8 +85,8 @@
                         <action selector="checkboxClicked:" target="-2" id="35J-zY-RjS"/>
                     </connections>
                 </button>
-                <button translatesAutoresizingMaskIntoConstraints="NO" id="qet-kh-hRB">
-                    <rect key="frame" x="8" y="45" width="462" height="18"/>
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qet-kh-hRB">
+                    <rect key="frame" x="20" y="46" width="420" height="16"/>
                     <buttonCell key="cell" type="check" title="Prefer golden cards when exporting to Hearthstone" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="1BI-nh-nxq">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -94,8 +95,8 @@
                         <action selector="checkboxClicked:" target="-2" id="glN-oA-TCo"/>
                     </connections>
                 </button>
-                <button translatesAutoresizingMaskIntoConstraints="NO" id="ONL-4k-EMK">
-                    <rect key="frame" x="8" y="19" width="462" height="18"/>
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ONL-4k-EMK">
+                    <rect key="frame" x="20" y="20" width="420" height="16"/>
                     <buttonCell key="cell" type="check" title="Use Toast notifications instead of Notification Center" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="XEI-kJ-kec">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -105,34 +106,46 @@
                     </connections>
                 </button>
             </subviews>
+            <edgeInsets key="edgeInsets" left="20" right="20" top="20" bottom="20"/>
             <constraints>
-                <constraint firstItem="Yit-xi-gbj" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="10" id="0B0-QG-9Dn"/>
-                <constraint firstItem="hzK-vu-1RX" firstAttribute="top" secondItem="Yit-xi-gbj" secondAttribute="bottom" constant="10" id="4a4-F5-NRY"/>
-                <constraint firstAttribute="trailing" secondItem="9ux-qy-79X" secondAttribute="trailing" constant="10" id="B6W-5H-T3a"/>
-                <constraint firstAttribute="bottom" secondItem="ONL-4k-EMK" secondAttribute="bottom" constant="20" id="CmU-A2-Nae"/>
-                <constraint firstItem="ONL-4k-EMK" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="10" id="H05-wP-fpz"/>
-                <constraint firstAttribute="trailing" secondItem="qet-kh-hRB" secondAttribute="trailing" constant="10" id="Ioq-bs-dNt"/>
-                <constraint firstAttribute="trailing" secondItem="hzK-vu-1RX" secondAttribute="trailing" constant="10" id="M9w-fO-gOz"/>
-                <constraint firstItem="qet-kh-hRB" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="10" id="RUZ-Jt-5XX"/>
-                <constraint firstItem="08B-rI-8LA" firstAttribute="top" secondItem="c22-O7-iKe" secondAttribute="top" constant="20" id="VaG-S9-qeb"/>
-                <constraint firstItem="c8y-VJ-p2U" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="10" id="Vdd-JU-GGZ"/>
-                <constraint firstAttribute="trailing" secondItem="08B-rI-8LA" secondAttribute="trailing" constant="10" id="XDP-fc-z3O"/>
-                <constraint firstAttribute="trailing" secondItem="c8y-VJ-p2U" secondAttribute="trailing" constant="10" id="XoQ-1A-pYd"/>
-                <constraint firstItem="c8y-VJ-p2U" firstAttribute="top" secondItem="08B-rI-8LA" secondAttribute="bottom" constant="10" id="aGW-Oi-8PP"/>
-                <constraint firstItem="Yit-xi-gbj" firstAttribute="top" secondItem="c8y-VJ-p2U" secondAttribute="bottom" constant="10" id="b5F-d8-vYj"/>
-                <constraint firstItem="9ux-qy-79X" firstAttribute="top" secondItem="lku-8T-sZE" secondAttribute="bottom" constant="10" id="bYA-Ja-Ahm"/>
-                <constraint firstItem="qet-kh-hRB" firstAttribute="top" secondItem="9ux-qy-79X" secondAttribute="bottom" constant="10" id="cIT-WU-phQ"/>
-                <constraint firstAttribute="trailing" secondItem="ONL-4k-EMK" secondAttribute="trailing" constant="10" id="gel-Ja-p1p"/>
-                <constraint firstAttribute="trailing" secondItem="Yit-xi-gbj" secondAttribute="trailing" constant="10" id="ii7-vq-aXk"/>
-                <constraint firstItem="hzK-vu-1RX" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="10" id="k3f-ob-5z7"/>
-                <constraint firstItem="08B-rI-8LA" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="10" id="m85-2p-jMA"/>
-                <constraint firstItem="ONL-4k-EMK" firstAttribute="top" secondItem="qet-kh-hRB" secondAttribute="bottom" constant="10" id="mDZ-eW-qjh"/>
-                <constraint firstAttribute="trailing" secondItem="lku-8T-sZE" secondAttribute="trailing" constant="10" id="qyB-h6-3qv"/>
-                <constraint firstItem="lku-8T-sZE" firstAttribute="top" secondItem="hzK-vu-1RX" secondAttribute="bottom" constant="10" id="tBF-uQ-1Sj"/>
-                <constraint firstItem="9ux-qy-79X" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="10" id="tfw-qJ-dwG"/>
-                <constraint firstItem="lku-8T-sZE" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="10" id="vqx-Up-9VW"/>
+                <constraint firstItem="08B-rI-8LA" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="20" symbolic="YES" id="gen-l0-08B"/>
+                <constraint firstItem="c8y-VJ-p2U" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="20" symbolic="YES" id="gen-l1-c8y"/>
+                <constraint firstItem="Yit-xi-gbj" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="20" symbolic="YES" id="gen-l2-Yit"/>
+                <constraint firstItem="hzK-vu-1RX" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="20" symbolic="YES" id="gen-l3-hzK"/>
+                <constraint firstItem="lku-8T-sZE" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="20" symbolic="YES" id="gen-l4-lku"/>
+                <constraint firstItem="9ux-qy-79X" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="20" symbolic="YES" id="gen-l5-9ux"/>
+                <constraint firstItem="qet-kh-hRB" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="20" symbolic="YES" id="gen-l6-qet"/>
+                <constraint firstItem="ONL-4k-EMK" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="20" symbolic="YES" id="gen-l7-ONL"/>
+                <constraint firstAttribute="trailing" secondItem="08B-rI-8LA" secondAttribute="trailing" constant="20" symbolic="YES" id="gen-t0-08B"/>
+                <constraint firstAttribute="trailing" secondItem="c8y-VJ-p2U" secondAttribute="trailing" constant="20" symbolic="YES" id="gen-t1-c8y"/>
+                <constraint firstAttribute="trailing" secondItem="Yit-xi-gbj" secondAttribute="trailing" constant="20" symbolic="YES" id="gen-t2-Yit"/>
+                <constraint firstAttribute="trailing" secondItem="hzK-vu-1RX" secondAttribute="trailing" constant="20" symbolic="YES" id="gen-t3-hzK"/>
+                <constraint firstAttribute="trailing" secondItem="lku-8T-sZE" secondAttribute="trailing" constant="20" symbolic="YES" id="gen-t4-lku"/>
+                <constraint firstAttribute="trailing" secondItem="9ux-qy-79X" secondAttribute="trailing" constant="20" symbolic="YES" id="gen-t5-9ux"/>
+                <constraint firstAttribute="trailing" secondItem="qet-kh-hRB" secondAttribute="trailing" constant="20" symbolic="YES" id="gen-t6-qet"/>
+                <constraint firstAttribute="trailing" secondItem="ONL-4k-EMK" secondAttribute="trailing" constant="20" symbolic="YES" id="gen-t7-ONL"/>
             </constraints>
+            <visibilityPriorities>
+                <integer value="1000"/>
+                <integer value="1000"/>
+                <integer value="1000"/>
+                <integer value="1000"/>
+                <integer value="1000"/>
+                <integer value="1000"/>
+                <integer value="1000"/>
+                <integer value="1000"/>
+            </visibilityPriorities>
+            <customSpacing>
+                <real value="3.4028234663852886e+38"/>
+                <real value="3.4028234663852886e+38"/>
+                <real value="3.4028234663852886e+38"/>
+                <real value="3.4028234663852886e+38"/>
+                <real value="3.4028234663852886e+38"/>
+                <real value="3.4028234663852886e+38"/>
+                <real value="3.4028234663852886e+38"/>
+                <real value="3.4028234663852886e+38"/>
+            </customSpacing>
             <point key="canvasLocation" x="11" y="51.5"/>
-        </customView>
+        </stackView>
     </objects>
 </document>

--- a/HSTracker/UIs/Preferences/Base.lproj/ImportingPreferences.xib
+++ b/HSTracker/UIs/Preferences/Base.lproj/ImportingPreferences.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23727" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24765" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23727"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24765"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -24,21 +24,21 @@
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <box title="Arena" translatesAutoresizingMaskIntoConstraints="NO" id="HEh-ts-ef2" userLabel="Arena">
-                    <rect key="frame" x="-3" y="258" width="466" height="92"/>
+                    <rect key="frame" x="20" y="280" width="420" height="90"/>
                     <view key="contentView" id="w35-IN-dcr">
-                        <rect key="frame" x="4" y="5" width="458" height="72"/>
+                        <rect key="frame" x="0.0" y="0.0" width="420" height="78"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ATG-Vp-W7D">
-                                <rect key="frame" x="18" y="44" width="64" height="16"/>
-                                <textFieldCell key="cell" lineBreakMode="clipping" title="Template:" id="1mZ-nx-a5i">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ATG-Vp-W7D">
+                                <rect key="frame" x="8" y="48" width="60" height="16"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" title="Template" id="1mZ-nx-a5i">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="CVF-Kj-FIP" userLabel="Arena Text Field">
-                                <rect key="frame" x="90" y="41" width="348" height="21"/>
+                            <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="CVF-Kj-FIP" userLabel="Arena Text Field">
+                                <rect key="frame" x="76" y="44" width="334" height="24"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="gP1-9g-YCR">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -48,16 +48,16 @@
                                     <outlet property="delegate" destination="-2" id="Fkp-VT-oyb"/>
                                 </connections>
                             </textField>
-                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hBl-r4-KLj">
-                                <rect key="frame" x="18" y="13" width="64" height="16"/>
-                                <textFieldCell key="cell" lineBreakMode="clipping" title="Preview:" id="CCL-UG-dMB">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hBl-r4-KLj">
+                                <rect key="frame" x="8" y="14" width="60" height="16"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" title="Preview" id="CCL-UG-dMB">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField focusRingType="none" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cMN-mz-gPi" userLabel="Preview Text Field">
-                                <rect key="frame" x="90" y="10" width="348" height="21"/>
+                            <textField verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cMN-mz-gPi" userLabel="Preview Text Field">
+                                <rect key="frame" x="76" y="10" width="334" height="24"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" enabled="NO" refusesFirstResponder="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="6vc-Fs-2Rf">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -68,13 +68,13 @@
                         <constraints>
                             <constraint firstItem="cMN-mz-gPi" firstAttribute="leading" secondItem="hBl-r4-KLj" secondAttribute="trailing" constant="10" id="0Js-Gw-O7A"/>
                             <constraint firstItem="CVF-Kj-FIP" firstAttribute="centerY" secondItem="ATG-Vp-W7D" secondAttribute="centerY" id="2a2-Hm-iKD"/>
-                            <constraint firstItem="ATG-Vp-W7D" firstAttribute="leading" secondItem="w35-IN-dcr" secondAttribute="leading" constant="20" id="I5G-rx-uHO"/>
+                            <constraint firstItem="ATG-Vp-W7D" firstAttribute="leading" secondItem="w35-IN-dcr" secondAttribute="leading" constant="10" id="I5G-rx-uHO"/>
                             <constraint firstItem="CVF-Kj-FIP" firstAttribute="top" secondItem="w35-IN-dcr" secondAttribute="top" constant="10" id="JPP-g7-Zv8"/>
-                            <constraint firstItem="hBl-r4-KLj" firstAttribute="leading" secondItem="w35-IN-dcr" secondAttribute="leading" constant="20" id="S5z-wk-kQY"/>
+                            <constraint firstItem="hBl-r4-KLj" firstAttribute="leading" secondItem="w35-IN-dcr" secondAttribute="leading" constant="10" id="S5z-wk-kQY"/>
                             <constraint firstItem="cMN-mz-gPi" firstAttribute="top" secondItem="CVF-Kj-FIP" secondAttribute="bottom" constant="10" id="a45-WZ-ko7"/>
-                            <constraint firstAttribute="trailing" secondItem="CVF-Kj-FIP" secondAttribute="trailing" constant="20" id="k8h-EM-nnD"/>
+                            <constraint firstAttribute="trailing" secondItem="CVF-Kj-FIP" secondAttribute="trailing" constant="10" id="k8h-EM-nnD"/>
                             <constraint firstItem="CVF-Kj-FIP" firstAttribute="leading" secondItem="ATG-Vp-W7D" secondAttribute="trailing" constant="10" id="kNt-7r-jBn"/>
-                            <constraint firstAttribute="trailing" secondItem="cMN-mz-gPi" secondAttribute="trailing" constant="20" id="oM0-gZ-HWc"/>
+                            <constraint firstAttribute="trailing" secondItem="cMN-mz-gPi" secondAttribute="trailing" constant="10" id="oM0-gZ-HWc"/>
                             <constraint firstItem="hBl-r4-KLj" firstAttribute="width" secondItem="ATG-Vp-W7D" secondAttribute="width" id="qK1-aC-Zp7"/>
                             <constraint firstAttribute="bottom" secondItem="cMN-mz-gPi" secondAttribute="bottom" constant="10" id="wcE-rf-muE"/>
                             <constraint firstItem="cMN-mz-gPi" firstAttribute="centerY" secondItem="hBl-r4-KLj" secondAttribute="centerY" id="x7x-sJ-9pV"/>
@@ -82,13 +82,13 @@
                     </view>
                 </box>
                 <box title="Dungeon" translatesAutoresizingMaskIntoConstraints="NO" id="NFi-sm-q5V">
-                    <rect key="frame" x="-3" y="104" width="466" height="148"/>
+                    <rect key="frame" x="20" y="120" width="420" height="150"/>
                     <view key="contentView" id="5nW-GB-ntj">
-                        <rect key="frame" x="4" y="5" width="458" height="128"/>
+                        <rect key="frame" x="0.0" y="0.0" width="420" height="138"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jaj-mw-nRa">
-                                <rect key="frame" x="18" y="101" width="420" height="18"/>
+                                <rect key="frame" x="10" y="112" width="400" height="16"/>
                                 <buttonCell key="cell" type="check" title="Include passive cards" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="bod-R2-2UP">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -97,16 +97,16 @@
                                     <action selector="checkboxClicked:" target="-2" id="xBp-fy-35t"/>
                                 </connections>
                             </button>
-                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lSo-Sw-Fds">
-                                <rect key="frame" x="18" y="74" width="70" height="16"/>
-                                <textFieldCell key="cell" lineBreakMode="clipping" title="Adventure:" id="7ai-aJ-h72">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lSo-Sw-Fds">
+                                <rect key="frame" x="8" y="82" width="66" height="16"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" title="Adventure" id="7ai-aJ-h72">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <comboBox focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="gfO-KN-jOc" userLabel="AdventureCB">
-                                <rect key="frame" x="95" y="70" width="346" height="23"/>
+                            <comboBox verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="gfO-KN-jOc" userLabel="AdventureCB">
+                                <rect key="frame" x="82" y="78" width="328" height="24"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="320" id="mbE-bd-1oE"/>
                                 </constraints>
@@ -126,16 +126,16 @@
                                     <action selector="comboboxChange:" target="-2" id="IUT-AR-cXp"/>
                                 </connections>
                             </comboBox>
-                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="zmD-0g-GGx">
-                                <rect key="frame" x="18" y="44" width="70" height="16"/>
-                                <textFieldCell key="cell" lineBreakMode="clipping" title="Template:" id="Mao-2y-Nix">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="zmD-0g-GGx">
+                                <rect key="frame" x="8" y="48" width="66" height="16"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" title="Template" id="Mao-2y-Nix">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField focusRingType="none" verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Cvb-8h-RiM" userLabel="TemplateField">
-                                <rect key="frame" x="96" y="41" width="342" height="21"/>
+                            <textField verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Cvb-8h-RiM" userLabel="TemplateField">
+                                <rect key="frame" x="82" y="44" width="328" height="24"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="0Cy-37-zMZ">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -145,16 +145,16 @@
                                     <outlet property="delegate" destination="-2" id="Y4X-A6-IwA"/>
                                 </connections>
                             </textField>
-                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0IW-DF-icw">
-                                <rect key="frame" x="18" y="13" width="70" height="16"/>
-                                <textFieldCell key="cell" lineBreakMode="clipping" title="Preview:" id="sYs-ss-jJm">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0IW-DF-icw">
+                                <rect key="frame" x="8" y="14" width="66" height="16"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" title="Preview" id="sYs-ss-jJm">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField focusRingType="none" verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MHY-Vx-Kio" userLabel="PreviewField">
-                                <rect key="frame" x="96" y="10" width="342" height="21"/>
+                            <textField verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MHY-Vx-Kio" userLabel="PreviewField">
+                                <rect key="frame" x="82" y="10" width="328" height="24"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" enabled="NO" refusesFirstResponder="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="Gbu-xZ-L6g">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -165,13 +165,13 @@
                         <constraints>
                             <constraint firstItem="Cvb-8h-RiM" firstAttribute="centerY" secondItem="zmD-0g-GGx" secondAttribute="centerY" id="1Ye-hO-veR"/>
                             <constraint firstItem="gfO-KN-jOc" firstAttribute="top" secondItem="jaj-mw-nRa" secondAttribute="bottom" constant="10" id="3g3-gH-wI5"/>
-                            <constraint firstAttribute="trailing" secondItem="MHY-Vx-Kio" secondAttribute="trailing" constant="20" id="3xY-wo-DdQ"/>
-                            <constraint firstItem="lSo-Sw-Fds" firstAttribute="leading" secondItem="5nW-GB-ntj" secondAttribute="leading" constant="20" id="BoQ-mc-Y7F"/>
-                            <constraint firstItem="zmD-0g-GGx" firstAttribute="leading" secondItem="5nW-GB-ntj" secondAttribute="leading" constant="20" id="H3I-Ym-X85"/>
+                            <constraint firstAttribute="trailing" secondItem="MHY-Vx-Kio" secondAttribute="trailing" constant="10" id="3xY-wo-DdQ"/>
+                            <constraint firstItem="lSo-Sw-Fds" firstAttribute="leading" secondItem="5nW-GB-ntj" secondAttribute="leading" constant="10" id="BoQ-mc-Y7F"/>
+                            <constraint firstItem="zmD-0g-GGx" firstAttribute="leading" secondItem="5nW-GB-ntj" secondAttribute="leading" constant="10" id="H3I-Ym-X85"/>
                             <constraint firstItem="Cvb-8h-RiM" firstAttribute="leading" secondItem="zmD-0g-GGx" secondAttribute="trailing" constant="10" id="NTt-4x-aoI"/>
-                            <constraint firstAttribute="trailing" secondItem="gfO-KN-jOc" secondAttribute="trailing" constant="20" id="OPt-xg-nso"/>
-                            <constraint firstAttribute="trailing" secondItem="Cvb-8h-RiM" secondAttribute="trailing" constant="20" id="Olj-fH-ubw"/>
-                            <constraint firstAttribute="trailing" secondItem="jaj-mw-nRa" secondAttribute="trailing" constant="20" id="QDQ-eH-dyA"/>
+                            <constraint firstAttribute="trailing" secondItem="gfO-KN-jOc" secondAttribute="trailing" constant="10" id="OPt-xg-nso"/>
+                            <constraint firstAttribute="trailing" secondItem="Cvb-8h-RiM" secondAttribute="trailing" constant="10" id="Olj-fH-ubw"/>
+                            <constraint firstAttribute="trailing" secondItem="jaj-mw-nRa" secondAttribute="trailing" constant="10" id="QDQ-eH-dyA"/>
                             <constraint firstItem="MHY-Vx-Kio" firstAttribute="leading" secondItem="0IW-DF-icw" secondAttribute="trailing" constant="10" id="a6h-Ru-QEq"/>
                             <constraint firstItem="gfO-KN-jOc" firstAttribute="leading" secondItem="lSo-Sw-Fds" secondAttribute="trailing" constant="10" id="aqM-7W-Sj0"/>
                             <constraint firstItem="Cvb-8h-RiM" firstAttribute="top" secondItem="gfO-KN-jOc" secondAttribute="bottom" constant="10" id="b4d-R7-RHx"/>
@@ -182,27 +182,27 @@
                             <constraint firstAttribute="bottom" secondItem="MHY-Vx-Kio" secondAttribute="bottom" constant="10" id="vQz-0Q-C0r"/>
                             <constraint firstItem="gfO-KN-jOc" firstAttribute="centerY" secondItem="lSo-Sw-Fds" secondAttribute="centerY" id="xBc-Ng-dRe"/>
                             <constraint firstItem="jaj-mw-nRa" firstAttribute="top" secondItem="5nW-GB-ntj" secondAttribute="top" constant="10" id="xe8-Uu-Vp4"/>
-                            <constraint firstItem="0IW-DF-icw" firstAttribute="leading" secondItem="5nW-GB-ntj" secondAttribute="leading" constant="20" id="y1b-6R-boF"/>
-                            <constraint firstItem="jaj-mw-nRa" firstAttribute="leading" secondItem="5nW-GB-ntj" secondAttribute="leading" constant="20" id="zHs-lc-J1g"/>
+                            <constraint firstItem="0IW-DF-icw" firstAttribute="leading" secondItem="5nW-GB-ntj" secondAttribute="leading" constant="10" id="y1b-6R-boF"/>
+                            <constraint firstItem="jaj-mw-nRa" firstAttribute="leading" secondItem="5nW-GB-ntj" secondAttribute="leading" constant="10" id="zHs-lc-J1g"/>
                         </constraints>
                     </view>
                 </box>
                 <box title="Duels" translatesAutoresizingMaskIntoConstraints="NO" id="j3y-jR-Itg">
-                    <rect key="frame" x="-3" y="6" width="466" height="92"/>
+                    <rect key="frame" x="20" y="20" width="420" height="90"/>
                     <view key="contentView" id="tNE-Tb-t8O">
-                        <rect key="frame" x="4" y="5" width="458" height="72"/>
+                        <rect key="frame" x="0.0" y="0.0" width="420" height="78"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cvs-Bx-FLl">
-                                <rect key="frame" x="18" y="44" width="64" height="16"/>
-                                <textFieldCell key="cell" lineBreakMode="clipping" title="Template:" id="aNg-mm-TjR">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cvs-Bx-FLl">
+                                <rect key="frame" x="8" y="48" width="60" height="16"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" title="Template" id="aNg-mm-TjR">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xXP-dH-hDG" userLabel="Duels Text Field">
-                                <rect key="frame" x="90" y="41" width="348" height="21"/>
+                            <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xXP-dH-hDG" userLabel="Duels Text Field">
+                                <rect key="frame" x="76" y="44" width="334" height="24"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="g5s-eb-7zN">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -212,16 +212,16 @@
                                     <outlet property="delegate" destination="-2" id="17z-O4-7ia"/>
                                 </connections>
                             </textField>
-                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ugf-m2-8PY">
-                                <rect key="frame" x="18" y="13" width="64" height="16"/>
-                                <textFieldCell key="cell" lineBreakMode="clipping" title="Preview:" id="OLn-BZ-Zzh">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ugf-m2-8PY">
+                                <rect key="frame" x="8" y="14" width="60" height="16"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" title="Preview" id="OLn-BZ-Zzh">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField focusRingType="none" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WTo-Jc-xjG" userLabel="Preview Text Field">
-                                <rect key="frame" x="90" y="10" width="348" height="21"/>
+                            <textField verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WTo-Jc-xjG" userLabel="Preview Text Field">
+                                <rect key="frame" x="76" y="10" width="334" height="24"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" enabled="NO" refusesFirstResponder="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="lH8-Rx-K9a">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -231,14 +231,14 @@
                         </subviews>
                         <constraints>
                             <constraint firstItem="xXP-dH-hDG" firstAttribute="leading" secondItem="cvs-Bx-FLl" secondAttribute="trailing" constant="10" id="0OK-Iu-uZO"/>
-                            <constraint firstItem="cvs-Bx-FLl" firstAttribute="leading" secondItem="tNE-Tb-t8O" secondAttribute="leading" constant="20" id="0rW-KT-1d0"/>
+                            <constraint firstItem="cvs-Bx-FLl" firstAttribute="leading" secondItem="tNE-Tb-t8O" secondAttribute="leading" constant="10" id="0rW-KT-1d0"/>
                             <constraint firstAttribute="bottom" secondItem="WTo-Jc-xjG" secondAttribute="bottom" constant="10" id="7i3-ss-OL9"/>
                             <constraint firstItem="xXP-dH-hDG" firstAttribute="centerY" secondItem="cvs-Bx-FLl" secondAttribute="centerY" id="IrD-am-tdO"/>
-                            <constraint firstAttribute="trailing" secondItem="WTo-Jc-xjG" secondAttribute="trailing" constant="20" id="KZr-AM-b5h"/>
-                            <constraint firstItem="ugf-m2-8PY" firstAttribute="leading" secondItem="tNE-Tb-t8O" secondAttribute="leading" constant="20" id="NaK-FK-PPB"/>
+                            <constraint firstAttribute="trailing" secondItem="WTo-Jc-xjG" secondAttribute="trailing" constant="10" id="KZr-AM-b5h"/>
+                            <constraint firstItem="ugf-m2-8PY" firstAttribute="leading" secondItem="tNE-Tb-t8O" secondAttribute="leading" constant="10" id="NaK-FK-PPB"/>
                             <constraint firstItem="WTo-Jc-xjG" firstAttribute="top" secondItem="xXP-dH-hDG" secondAttribute="bottom" constant="10" id="WmR-9t-Q74"/>
                             <constraint firstItem="WTo-Jc-xjG" firstAttribute="leading" secondItem="ugf-m2-8PY" secondAttribute="trailing" constant="10" id="Zua-5o-O1L"/>
-                            <constraint firstAttribute="trailing" secondItem="xXP-dH-hDG" secondAttribute="trailing" constant="20" id="a45-fs-Lo3"/>
+                            <constraint firstAttribute="trailing" secondItem="xXP-dH-hDG" secondAttribute="trailing" constant="10" id="a45-fs-Lo3"/>
                             <constraint firstItem="WTo-Jc-xjG" firstAttribute="centerY" secondItem="ugf-m2-8PY" secondAttribute="centerY" id="eE8-mr-dAa"/>
                             <constraint firstItem="xXP-dH-hDG" firstAttribute="top" secondItem="tNE-Tb-t8O" secondAttribute="top" constant="10" id="f63-3a-V7A"/>
                             <constraint firstItem="ugf-m2-8PY" firstAttribute="width" secondItem="cvs-Bx-FLl" secondAttribute="width" id="uPk-pH-jPJ"/>
@@ -246,14 +246,14 @@
                     </view>
                 </box>
             </subviews>
-            <edgeInsets key="edgeInsets" left="20" right="20" top="10" bottom="10"/>
+            <edgeInsets key="edgeInsets" left="20" right="20" top="20" bottom="20"/>
             <constraints>
-                <constraint firstItem="HEh-ts-ef2" firstAttribute="leading" secondItem="RQ5-ae-Wk6" secondAttribute="leading" id="HZk-3X-XO3"/>
-                <constraint firstAttribute="trailing" secondItem="j3y-jR-Itg" secondAttribute="trailing" id="d1m-am-d0F"/>
-                <constraint firstAttribute="trailing" secondItem="NFi-sm-q5V" secondAttribute="trailing" id="f5o-d6-Kh4"/>
-                <constraint firstItem="j3y-jR-Itg" firstAttribute="leading" secondItem="RQ5-ae-Wk6" secondAttribute="leading" id="j6n-ls-zoi"/>
-                <constraint firstItem="NFi-sm-q5V" firstAttribute="leading" secondItem="RQ5-ae-Wk6" secondAttribute="leading" id="ljD-1a-h28"/>
-                <constraint firstAttribute="trailing" secondItem="HEh-ts-ef2" secondAttribute="trailing" id="mXG-tM-Alg"/>
+                <constraint firstItem="HEh-ts-ef2" firstAttribute="leading" secondItem="RQ5-ae-Wk6" secondAttribute="leading" constant="20" id="HZk-3X-XO3"/>
+                <constraint firstAttribute="trailing" secondItem="j3y-jR-Itg" secondAttribute="trailing" constant="20" id="d1m-am-d0F"/>
+                <constraint firstAttribute="trailing" secondItem="NFi-sm-q5V" secondAttribute="trailing" constant="20" id="f5o-d6-Kh4"/>
+                <constraint firstItem="j3y-jR-Itg" firstAttribute="leading" secondItem="RQ5-ae-Wk6" secondAttribute="leading" constant="20" id="j6n-ls-zoi"/>
+                <constraint firstItem="NFi-sm-q5V" firstAttribute="leading" secondItem="RQ5-ae-Wk6" secondAttribute="leading" constant="20" id="ljD-1a-h28"/>
+                <constraint firstAttribute="trailing" secondItem="HEh-ts-ef2" secondAttribute="trailing" constant="20" id="mXG-tM-Alg"/>
             </constraints>
             <visibilityPriorities>
                 <integer value="1000"/>

--- a/HSTracker/UIs/Preferences/Base.lproj/MercenariesPreferences.xib
+++ b/HSTracker/UIs/Preferences/Base.lproj/MercenariesPreferences.xib
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19455" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24765" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19455"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24765"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -18,11 +17,12 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="c22-O7-iKe">
-            <rect key="frame" x="0.0" y="0.0" width="475" height="140"/>
+        <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="10" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" id="c22-O7-iKe">
+            <rect key="frame" x="0.0" y="0.0" width="460" height="160"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <button verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="U9l-4H-26w">
-                    <rect key="frame" x="18" y="113" width="437" height="18"/>
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="U9l-4H-26w">
+                    <rect key="frame" x="20" y="124" width="420" height="16"/>
                     <buttonCell key="cell" type="check" title="Show opponent Mercenary abilities on hover" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="i84-xc-QhF">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -31,8 +31,8 @@
                         <action selector="checkboxClicked:" target="-2" id="SCo-fj-gdt"/>
                     </connections>
                 </button>
-                <button translatesAutoresizingMaskIntoConstraints="NO" id="d7f-Kb-z3w">
-                    <rect key="frame" x="18" y="87" width="437" height="18"/>
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="d7f-Kb-z3w">
+                    <rect key="frame" x="20" y="98" width="420" height="16"/>
                     <buttonCell key="cell" type="check" title="Show player Mercenary abilities on hover" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="QMN-RN-SBa">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -42,7 +42,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Xan-kV-3qo">
-                    <rect key="frame" x="18" y="61" width="437" height="18"/>
+                    <rect key="frame" x="20" y="72" width="420" height="16"/>
                     <buttonCell key="cell" type="check" title="Show ability icons above opponent Mercenaries" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="yHd-sB-xlv">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -52,7 +52,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="h7j-Vy-LgF">
-                    <rect key="frame" x="18" y="35" width="437" height="18"/>
+                    <rect key="frame" x="20" y="46" width="420" height="16"/>
                     <buttonCell key="cell" type="check" title="Show ability icons below player Mercenaries" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="bkp-KW-tQa">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -61,8 +61,8 @@
                         <action selector="checkboxClicked:" target="-2" id="P9e-jB-0qt"/>
                     </connections>
                 </button>
-                <button verticalHuggingPriority="251" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="8sm-QA-fRQ" userLabel="Show Tasks panel while in Mercenaries mode">
-                    <rect key="frame" x="18" y="9" width="437" height="18"/>
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8sm-QA-fRQ" userLabel="Show Tasks panel while in Mercenaries mode">
+                    <rect key="frame" x="20" y="20" width="420" height="16"/>
                     <buttonCell key="cell" type="check" title="Show Tasks panel while in Mercenaries mode" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="xHF-kI-BcO" userLabel=" Show Tasks panel while in Mercenaries mode">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -72,25 +72,34 @@
                     </connections>
                 </button>
             </subviews>
+            <edgeInsets key="edgeInsets" left="20" right="20" top="20" bottom="20"/>
             <constraints>
-                <constraint firstItem="h7j-Vy-LgF" firstAttribute="top" secondItem="Xan-kV-3qo" secondAttribute="bottom" constant="10" id="0sf-2V-83d"/>
-                <constraint firstItem="8sm-QA-fRQ" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="20" id="5hN-nd-t3l"/>
-                <constraint firstAttribute="bottom" secondItem="8sm-QA-fRQ" secondAttribute="bottom" constant="10" id="66a-ae-ox9"/>
-                <constraint firstItem="d7f-Kb-z3w" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="20" id="8ab-oS-4lf"/>
-                <constraint firstAttribute="trailing" secondItem="d7f-Kb-z3w" secondAttribute="trailing" constant="20" id="9RS-R2-V55"/>
-                <constraint firstItem="U9l-4H-26w" firstAttribute="top" secondItem="c22-O7-iKe" secondAttribute="top" constant="10" id="Dlh-3q-q93"/>
-                <constraint firstAttribute="trailing" secondItem="U9l-4H-26w" secondAttribute="trailing" constant="20" id="FUh-8L-7N7"/>
-                <constraint firstItem="h7j-Vy-LgF" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="20" id="G8w-kn-rAD"/>
-                <constraint firstAttribute="trailing" secondItem="8sm-QA-fRQ" secondAttribute="trailing" constant="20" id="Gtq-EJ-Gpn"/>
-                <constraint firstItem="d7f-Kb-z3w" firstAttribute="top" secondItem="U9l-4H-26w" secondAttribute="bottom" constant="10" id="M40-qk-aPz"/>
-                <constraint firstAttribute="trailing" secondItem="Xan-kV-3qo" secondAttribute="trailing" constant="20" id="Rp3-Mf-3id"/>
-                <constraint firstItem="8sm-QA-fRQ" firstAttribute="top" secondItem="h7j-Vy-LgF" secondAttribute="bottom" constant="10" id="Uz2-BY-yif"/>
-                <constraint firstAttribute="trailing" secondItem="h7j-Vy-LgF" secondAttribute="trailing" constant="20" id="ZSI-rV-puT"/>
-                <constraint firstItem="U9l-4H-26w" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="20" id="bzS-SZ-yhl"/>
-                <constraint firstItem="Xan-kV-3qo" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="20" id="edt-lS-o08"/>
-                <constraint firstItem="Xan-kV-3qo" firstAttribute="top" secondItem="d7f-Kb-z3w" secondAttribute="bottom" constant="10" id="wCc-Ra-Qnr"/>
+                <constraint firstItem="U9l-4H-26w" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="20" symbolic="YES" id="mrc-l0-U9l"/>
+                <constraint firstItem="d7f-Kb-z3w" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="20" symbolic="YES" id="mrc-l1-d7f"/>
+                <constraint firstItem="Xan-kV-3qo" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="20" symbolic="YES" id="mrc-l2-Xan"/>
+                <constraint firstItem="h7j-Vy-LgF" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="20" symbolic="YES" id="mrc-l3-h7j"/>
+                <constraint firstItem="8sm-QA-fRQ" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="20" symbolic="YES" id="mrc-l4-8sm"/>
+                <constraint firstAttribute="trailing" secondItem="U9l-4H-26w" secondAttribute="trailing" constant="20" symbolic="YES" id="mrc-t0-U9l"/>
+                <constraint firstAttribute="trailing" secondItem="d7f-Kb-z3w" secondAttribute="trailing" constant="20" symbolic="YES" id="mrc-t1-d7f"/>
+                <constraint firstAttribute="trailing" secondItem="Xan-kV-3qo" secondAttribute="trailing" constant="20" symbolic="YES" id="mrc-t2-Xan"/>
+                <constraint firstAttribute="trailing" secondItem="h7j-Vy-LgF" secondAttribute="trailing" constant="20" symbolic="YES" id="mrc-t3-h7j"/>
+                <constraint firstAttribute="trailing" secondItem="8sm-QA-fRQ" secondAttribute="trailing" constant="20" symbolic="YES" id="mrc-t4-8sm"/>
             </constraints>
+            <visibilityPriorities>
+                <integer value="1000"/>
+                <integer value="1000"/>
+                <integer value="1000"/>
+                <integer value="1000"/>
+                <integer value="1000"/>
+            </visibilityPriorities>
+            <customSpacing>
+                <real value="3.4028234663852886e+38"/>
+                <real value="3.4028234663852886e+38"/>
+                <real value="3.4028234663852886e+38"/>
+                <real value="3.4028234663852886e+38"/>
+                <real value="3.4028234663852886e+38"/>
+            </customSpacing>
             <point key="canvasLocation" x="64.5" y="-71"/>
-        </customView>
+        </stackView>
     </objects>
 </document>

--- a/HSTracker/UIs/Preferences/Base.lproj/OpponentTrackersPreferences.xib
+++ b/HSTracker/UIs/Preferences/Base.lproj/OpponentTrackersPreferences.xib
@@ -28,7 +28,7 @@
                 <outlet property="view" destination="DPe-et-cJR" id="cJe-z5-DVd"/>
             </connections>
         </customObject>
-        <stackView distribution="fill" orientation="vertical" alignment="centerX" spacing="10" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" id="DPe-et-cJR">
+        <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="10" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" id="DPe-et-cJR">
             <rect key="frame" x="0.0" y="0.0" width="432" height="428"/>
             <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
             <subviews>
@@ -219,7 +219,7 @@
                     </connections>
                 </button>
             </subviews>
-            <edgeInsets key="edgeInsets" left="20" right="20" top="10" bottom="10"/>
+            <edgeInsets key="edgeInsets" left="20" right="20" top="20" bottom="20"/>
             <constraints>
                 <constraint firstItem="GPS-bk-Bdd" firstAttribute="leading" secondItem="DPe-et-cJR" secondAttribute="leading" constant="20" symbolic="YES" id="0Hi-Xj-Gwf"/>
                 <constraint firstAttribute="trailing" secondItem="Vp4-QG-lNm" secondAttribute="trailing" constant="20" symbolic="YES" id="0p6-ep-pOo"/>

--- a/HSTracker/UIs/Preferences/Base.lproj/PlayerTrackersPreferences.xib
+++ b/HSTracker/UIs/Preferences/Base.lproj/PlayerTrackersPreferences.xib
@@ -33,7 +33,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <stackView distribution="fill" orientation="vertical" alignment="centerX" spacing="10" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" id="XxF-gV-LnW">
+        <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="10" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" id="XxF-gV-LnW">
             <rect key="frame" x="0.0" y="0.0" width="461" height="508"/>
             <autoresizingMask key="autoresizingMask"/>
             <subviews>
@@ -280,7 +280,7 @@
                     </connections>
                 </button>
             </subviews>
-            <edgeInsets key="edgeInsets" left="20" right="20" top="10" bottom="10"/>
+            <edgeInsets key="edgeInsets" left="20" right="20" top="20" bottom="20"/>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="9lC-T5-lQq" secondAttribute="trailing" constant="20" symbolic="YES" id="0A9-iR-L12"/>
                 <constraint firstItem="sgy-13-dsa" firstAttribute="leading" secondItem="XxF-gV-LnW" secondAttribute="leading" constant="20" symbolic="YES" id="3nH-NS-gqd"/>

--- a/HSTracker/UIs/Preferences/Base.lproj/TrackersPreferences.xib
+++ b/HSTracker/UIs/Preferences/Base.lproj/TrackersPreferences.xib
@@ -35,7 +35,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <stackView distribution="fill" orientation="vertical" alignment="centerX" spacing="10" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" id="51m-9V-RQO">
+        <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="10" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" id="51m-9V-RQO">
             <rect key="frame" x="0.0" y="0.0" width="339" height="594"/>
             <autoresizingMask key="autoresizingMask"/>
             <subviews>
@@ -324,9 +324,9 @@
                         <action selector="checkboxClicked:" target="-2" id="e2s-of-hkJ"/>
                     </connections>
                 </button>
-                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dj6-Ot-tpw" userLabel="Show Mulligan Overlay at start of game">
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dj6-Ot-tpw" userLabel="Show mulligan overlay at start of game">
                     <rect key="frame" x="18" y="61" width="301" height="18"/>
-                    <buttonCell key="cell" type="check" title="Show Mulligan Overlay at start of game" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="UXw-QE-lUP">
+                    <buttonCell key="cell" type="check" title="Show mulligan overlay at start of game" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="UXw-QE-lUP">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
@@ -355,7 +355,7 @@
                     </connections>
                 </button>
             </subviews>
-            <edgeInsets key="edgeInsets" left="20" right="20" top="10" bottom="10"/>
+            <edgeInsets key="edgeInsets" left="20" right="20" top="20" bottom="20"/>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="dj6-Ot-tpw" secondAttribute="trailing" constant="20" symbolic="YES" id="0jh-tg-Qbi"/>
                 <constraint firstAttribute="trailing" secondItem="7ps-Br-1Oh" secondAttribute="trailing" constant="20" symbolic="YES" id="1eg-U1-LOM"/>

--- a/HSTracker/UIs/Preferences/GamePreferences.swift
+++ b/HSTracker/UIs/Preferences/GamePreferences.swift
@@ -1,5 +1,5 @@
 //
-//  GamePrefences.swift
+//  GamePreferences.swift
 //  HSTracker
 //
 //  Created by Benjamin Michotte on 29/02/16.

--- a/HSTracker/UIs/Preferences/GeneralPreferences.swift
+++ b/HSTracker/UIs/Preferences/GeneralPreferences.swift
@@ -11,9 +11,9 @@ import Preferences
 
 class GeneralPreferences: PreferencePaneController, PreferencePane {
     var preferencePaneIdentifier = Preferences.PaneIdentifier.general
-    
+
     var preferencePaneTitle = String.localizedString("General", comment: "")
-    
+
     var toolbarItemIcon = NSImage(named: "settings-general")!
 
     @IBOutlet var notifyGameStart: NSButton!
@@ -24,10 +24,10 @@ class GeneralPreferences: PreferencePaneController, PreferencePane {
     @IBOutlet var enableDockBadge: NSButton!
     @IBOutlet var preferGoldenCards: NSButton!
     @IBOutlet var useToastNotifications: NSButton!
-	
+
     override func viewWillAppear() {
         super.viewWillAppear()
-        
+
         guard notifyGameStart != nil else {
             return
         }
@@ -39,7 +39,7 @@ class GeneralPreferences: PreferencePaneController, PreferencePane {
         saveReplays.state = Settings.saveReplays ? .on : .off
         enableDockBadge.state = Settings.showAppHealth ? .on : .off
         preferGoldenCards.state = Settings.preferGoldenCards ? .on : .off
-		useToastNotifications.state = Settings.useToastNotification ? .on : .off
+        useToastNotifications.state = Settings.useToastNotification ? .on : .off
     }
 
     @IBAction func checkboxClicked(_ sender: NSButton) {
@@ -58,9 +58,9 @@ class GeneralPreferences: PreferencePaneController, PreferencePane {
             AppHealth.instance.updateBadge()
         } else if sender == preferGoldenCards {
             Settings.preferGoldenCards = preferGoldenCards.state == .on
-		} else if sender == useToastNotifications {
-			Settings.useToastNotification = useToastNotifications.state == .on
-		}
+        } else if sender == useToastNotifications {
+            Settings.useToastNotification = useToastNotifications.state == .on
+        }
     }
 
 }

--- a/HSTracker/UIs/Preferences/de.lproj/GeneralPreferences.strings
+++ b/HSTracker/UIs/Preferences/de.lproj/GeneralPreferences.strings
@@ -26,8 +26,8 @@
 /* Class = "NSButtonCell"; title = "Save replays"; ObjectID = "lku-8T-sZE"; */
 "lku-8T-sZE.title" = "Replays speichern";
 
-/* Class = "NSButtonCell"; title = "Enable Apphealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
-"mBv-nX-Cn3.title" = "Aktiviere Apphealth Icon-Badge";
+/* Class = "NSButtonCell"; title = "Enable AppHealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
+"mBv-nX-Cn3.title" = "Aktiviere AppHealth Icon-Badge";
 
 /* Class = "NSButtonCell"; title = "Prefer golden cards when exporting to Hearthstone"; ObjectID = "1BI-nh-nxq"; */
 "1BI-nh-nxq.title" = "Bevorzuge goldene Karten beim Export zu Hearthstone";

--- a/HSTracker/UIs/Preferences/es-MX.lproj/GamePreferences.strings
+++ b/HSTracker/UIs/Preferences/es-MX.lproj/GamePreferences.strings
@@ -5,8 +5,8 @@
 /* Class = "NSTextFieldCell"; title = "Hearthstone language"; ObjectID = "biS-yx-frk"; */
 "biS-yx-frk.title" = "Hearthstone language";
 
-/* Class = "NSButtonCell"; title = "Auto archive arena deck on run end"; ObjectID = "hMe-FU-CjR"; */
-"hMe-FU-CjR.title" = "Auto archive arena deck on run end";
+/* Class = "NSButtonCell"; title = "Auto archive Arena deck on run end"; ObjectID = "hMe-FU-CjR"; */
+"hMe-FU-CjR.title" = "Auto archive Arena deck on run end";
 
 /* Class = "NSButtonCell"; title = "Auto import and select decks"; ObjectID = "mhj-j8-OPU"; */
 "mhj-j8-OPU.title" = "Auto import and select decks";

--- a/HSTracker/UIs/Preferences/es-MX.lproj/GeneralPreferences.strings
+++ b/HSTracker/UIs/Preferences/es-MX.lproj/GeneralPreferences.strings
@@ -32,8 +32,8 @@
 /* Class = "NSButton"; ibShadowedToolTip = "Notifications are only visible if Hearthstone is not focused"; ObjectID = "hzK-vu-1RX"; */
 "hzK-vu-1RX.ibShadowedToolTip" = "Notifications are only visible if Hearthstone is not focused";
 
-/* Class = "NSButtonCell"; title = "Enable Apphealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
-"mBv-nX-Cn3.title" = "Enable Apphealth icon badge";
+/* Class = "NSButtonCell"; title = "Enable AppHealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
+"mBv-nX-Cn3.title" = "Enable AppHealth icon badge";
 
 /* Class = "NSButtonCell"; title = "Close HSTracker when Hearthstone closes"; ObjectID = "oQm-3D-WOn"; */
 "oQm-3D-WOn.title" = "Close HSTracker when Hearthstone closes";

--- a/HSTracker/UIs/Preferences/es.lproj/GeneralPreferences.strings
+++ b/HSTracker/UIs/Preferences/es.lproj/GeneralPreferences.strings
@@ -26,8 +26,8 @@
 /* Class = "NSButtonCell"; title = "Save replays"; ObjectID = "lku-8T-sZE"; */
 "lku-8T-sZE.title" = "Save replays";
 
-/* Class = "NSButtonCell"; title = "Enable Apphealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
-"mBv-nX-Cn3.title" = "Enable Apphealth icon badge";
+/* Class = "NSButtonCell"; title = "Enable AppHealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
+"mBv-nX-Cn3.title" = "Enable AppHealth icon badge";
 
 /* Class = "NSButtonCell"; title = "Prefer golden cards when exporting to Hearthstone"; ObjectID = "1BI-nh-nxq"; */
 "1BI-nh-nxq.title" = "Prefer golden cards when exporting to Hearthstone";

--- a/HSTracker/UIs/Preferences/fr.lproj/GeneralPreferences.strings
+++ b/HSTracker/UIs/Preferences/fr.lproj/GeneralPreferences.strings
@@ -26,7 +26,7 @@
 /* Class = "NSButtonCell"; title = "Save replays"; ObjectID = "lku-8T-sZE"; */
 "lku-8T-sZE.title" = "Enregistrer les replays";
 
-/* Class = "NSButtonCell"; title = "Enable Apphealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
+/* Class = "NSButtonCell"; title = "Enable AppHealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
 "mBv-nX-Cn3.title" = "Activer le badge Santé de HSTracker";
 
 /* Class = "NSButtonCell"; title = "Prefer golden cards when exporting to Hearthstone"; ObjectID = "1BI-nh-nxq"; */

--- a/HSTracker/UIs/Preferences/it.lproj/GeneralPreferences.strings
+++ b/HSTracker/UIs/Preferences/it.lproj/GeneralPreferences.strings
@@ -26,8 +26,8 @@
 /* Class = "NSButtonCell"; title = "Save replays"; ObjectID = "lku-8T-sZE"; */
 "lku-8T-sZE.title" = "Save replays";
 
-/* Class = "NSButtonCell"; title = "Enable Apphealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
-"mBv-nX-Cn3.title" = "Enable Apphealth icon badge";
+/* Class = "NSButtonCell"; title = "Enable AppHealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
+"mBv-nX-Cn3.title" = "Enable AppHealth icon badge";
 
 /* Class = "NSButtonCell"; title = "Prefer golden cards when exporting to Hearthstone"; ObjectID = "1BI-nh-nxq"; */
 "1BI-nh-nxq.title" = "Prefer golden cards when exporting to Hearthstone";

--- a/HSTracker/UIs/Preferences/ja.lproj/GamePreferences.strings
+++ b/HSTracker/UIs/Preferences/ja.lproj/GamePreferences.strings
@@ -5,8 +5,8 @@
 /* Class = "NSTextFieldCell"; title = "Hearthstone language"; ObjectID = "biS-yx-frk"; */
 "biS-yx-frk.title" = "Hearthstone language";
 
-/* Class = "NSButtonCell"; title = "Auto archive arena deck on run end"; ObjectID = "hMe-FU-CjR"; */
-"hMe-FU-CjR.title" = "Auto archive arena deck on run end";
+/* Class = "NSButtonCell"; title = "Auto archive Arena deck on run end"; ObjectID = "hMe-FU-CjR"; */
+"hMe-FU-CjR.title" = "Auto archive Arena deck on run end";
 
 /* Class = "NSButtonCell"; title = "Auto import and select decks"; ObjectID = "mhj-j8-OPU"; */
 "mhj-j8-OPU.title" = "Auto import and select decks";

--- a/HSTracker/UIs/Preferences/ja.lproj/GeneralPreferences.strings
+++ b/HSTracker/UIs/Preferences/ja.lproj/GeneralPreferences.strings
@@ -32,8 +32,8 @@
 /* Class = "NSButton"; ibShadowedToolTip = "Notifications are only visible if Hearthstone is not focused"; ObjectID = "hzK-vu-1RX"; */
 "hzK-vu-1RX.ibShadowedToolTip" = "Notifications are only visible if Hearthstone is not focused";
 
-/* Class = "NSButtonCell"; title = "Enable Apphealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
-"mBv-nX-Cn3.title" = "Enable Apphealth icon badge";
+/* Class = "NSButtonCell"; title = "Enable AppHealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
+"mBv-nX-Cn3.title" = "Enable AppHealth icon badge";
 
 /* Class = "NSButtonCell"; title = "Close HSTracker when Hearthstone closes"; ObjectID = "oQm-3D-WOn"; */
 "oQm-3D-WOn.title" = "Close HSTracker when Hearthstone closes";

--- a/HSTracker/UIs/Preferences/ko-KR.lproj/GamePreferences.strings
+++ b/HSTracker/UIs/Preferences/ko-KR.lproj/GamePreferences.strings
@@ -4,7 +4,7 @@
 /* Class = "NSTextFieldCell"; title = "Hearthstone language"; ObjectID = "biS-yx-frk"; */
 "biS-yx-frk.title" = "Hearthstone 언어 선택";
 
-/* Class = "NSButtonCell"; title = "Auto archive arena deck on run end"; ObjectID = "hMe-FU-CjR"; */
+/* Class = "NSButtonCell"; title = "Auto archive Arena deck on run end"; ObjectID = "hMe-FU-CjR"; */
 "hMe-FU-CjR.title" = "투기장이 끝나면 자동으로 덱 저장하기";
 
 /* Class = "NSButtonCell"; title = "Auto import and select decks"; ObjectID = "mhj-j8-OPU"; */

--- a/HSTracker/UIs/Preferences/ko-KR.lproj/GeneralPreferences.strings
+++ b/HSTracker/UIs/Preferences/ko-KR.lproj/GeneralPreferences.strings
@@ -25,7 +25,7 @@
 /* Class = "NSButton"; ibShadowedToolTip = "Notifications are only visible if Hearthstone is not focused"; ObjectID = "hzK-vu-1RX"; */
 "hzK-vu-1RX.ibShadowedToolTip" = "하스스톤이 활성화 되어 있지 않을때만 알림이 나타나게 하기";
 
-/* Class = "NSButtonCell"; title = "Enable Apphealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
+/* Class = "NSButtonCell"; title = "Enable AppHealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
 "mBv-nX-Cn3.title" = "앱상태 배지아이콘 활성화";
 
 /* Class = "NSButtonCell"; title = "Close HSTracker when Hearthstone closes"; ObjectID = "oQm-3D-WOn"; */

--- a/HSTracker/UIs/Preferences/ko.lproj/GamePreferences.strings
+++ b/HSTracker/UIs/Preferences/ko.lproj/GamePreferences.strings
@@ -5,7 +5,7 @@
 /* Class = "NSTextFieldCell"; title = "Hearthstone language"; ObjectID = "biS-yx-frk"; */
 "biS-yx-frk.title" = "하스스톤 언어";
 
-/* Class = "NSButtonCell"; title = "Auto archive arena deck on run end"; ObjectID = "hMe-FU-CjR"; */
+/* Class = "NSButtonCell"; title = "Auto archive Arena deck on run end"; ObjectID = "hMe-FU-CjR"; */
 "hMe-FU-CjR.title" = "투기장이 끝나면 덱을 자동 저장하기";
 
 /* Class = "NSButtonCell"; title = "Auto import and select decks"; ObjectID = "mhj-j8-OPU"; */

--- a/HSTracker/UIs/Preferences/ko.lproj/GeneralPreferences.strings
+++ b/HSTracker/UIs/Preferences/ko.lproj/GeneralPreferences.strings
@@ -32,8 +32,8 @@
 /* Class = "NSButton"; ibShadowedToolTip = "Notifications are only visible if Hearthstone is not focused"; ObjectID = "hzK-vu-1RX"; */
 "hzK-vu-1RX.ibShadowedToolTip" = "Notifications은 포커스가 하스스톤에 있지 않을때만 나타나기";
 
-/* Class = "NSButtonCell"; title = "Enable Apphealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
-"mBv-nX-Cn3.title" = "Enable Apphealth icon badge";
+/* Class = "NSButtonCell"; title = "Enable AppHealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
+"mBv-nX-Cn3.title" = "Enable AppHealth icon badge";
 
 /* Class = "NSButtonCell"; title = "Close HSTracker when Hearthstone closes"; ObjectID = "oQm-3D-WOn"; */
 "oQm-3D-WOn.title" = "하스스톤을 종료하면 HSTracker도 종료하기";

--- a/HSTracker/UIs/Preferences/pl.lproj/GamePreferences.strings
+++ b/HSTracker/UIs/Preferences/pl.lproj/GamePreferences.strings
@@ -5,8 +5,8 @@
 /* Class = "NSTextFieldCell"; title = "Hearthstone language"; ObjectID = "biS-yx-frk"; */
 "biS-yx-frk.title" = "Hearthstone language";
 
-/* Class = "NSButtonCell"; title = "Auto archive arena deck on run end"; ObjectID = "hMe-FU-CjR"; */
-"hMe-FU-CjR.title" = "Auto archive arena deck on run end";
+/* Class = "NSButtonCell"; title = "Auto archive Arena deck on run end"; ObjectID = "hMe-FU-CjR"; */
+"hMe-FU-CjR.title" = "Auto archive Arena deck on run end";
 
 /* Class = "NSButtonCell"; title = "Auto import and select decks"; ObjectID = "mhj-j8-OPU"; */
 "mhj-j8-OPU.title" = "Auto import and select decks";

--- a/HSTracker/UIs/Preferences/pl.lproj/GeneralPreferences.strings
+++ b/HSTracker/UIs/Preferences/pl.lproj/GeneralPreferences.strings
@@ -32,8 +32,8 @@
 /* Class = "NSButton"; ibShadowedToolTip = "Notifications are only visible if Hearthstone is not focused"; ObjectID = "hzK-vu-1RX"; */
 "hzK-vu-1RX.ibShadowedToolTip" = "Notifications are only visible if Hearthstone is not focused";
 
-/* Class = "NSButtonCell"; title = "Enable Apphealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
-"mBv-nX-Cn3.title" = "Enable Apphealth icon badge";
+/* Class = "NSButtonCell"; title = "Enable AppHealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
+"mBv-nX-Cn3.title" = "Enable AppHealth icon badge";
 
 /* Class = "NSButtonCell"; title = "Close HSTracker when Hearthstone closes"; ObjectID = "oQm-3D-WOn"; */
 "oQm-3D-WOn.title" = "Close HSTracker when Hearthstone closes";

--- a/HSTracker/UIs/Preferences/pt-BR.lproj/GeneralPreferences.strings
+++ b/HSTracker/UIs/Preferences/pt-BR.lproj/GeneralPreferences.strings
@@ -26,8 +26,8 @@
 /* Class = "NSButtonCell"; title = "Save replays"; ObjectID = "lku-8T-sZE"; */
 "lku-8T-sZE.title" = "Save replays";
 
-/* Class = "NSButtonCell"; title = "Enable Apphealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
-"mBv-nX-Cn3.title" = "Enable Apphealth icon badge";
+/* Class = "NSButtonCell"; title = "Enable AppHealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
+"mBv-nX-Cn3.title" = "Enable AppHealth icon badge";
 
 /* Class = "NSButtonCell"; title = "Prefer golden cards when exporting to Hearthstone"; ObjectID = "1BI-nh-nxq"; */
 "1BI-nh-nxq.title" = "Prefer golden cards when exporting to Hearthstone";

--- a/HSTracker/UIs/Preferences/ru.lproj/GamePreferences.strings
+++ b/HSTracker/UIs/Preferences/ru.lproj/GamePreferences.strings
@@ -5,8 +5,8 @@
 /* Class = "NSTextFieldCell"; title = "Hearthstone language"; ObjectID = "biS-yx-frk"; */
 "biS-yx-frk.title" = "Hearthstone language";
 
-/* Class = "NSButtonCell"; title = "Auto archive arena deck on run end"; ObjectID = "hMe-FU-CjR"; */
-"hMe-FU-CjR.title" = "Auto archive arena deck on run end";
+/* Class = "NSButtonCell"; title = "Auto archive Arena deck on run end"; ObjectID = "hMe-FU-CjR"; */
+"hMe-FU-CjR.title" = "Auto archive Arena deck on run end";
 
 /* Class = "NSButtonCell"; title = "Auto import and select decks"; ObjectID = "mhj-j8-OPU"; */
 "mhj-j8-OPU.title" = "Auto import and select decks";

--- a/HSTracker/UIs/Preferences/ru.lproj/GeneralPreferences.strings
+++ b/HSTracker/UIs/Preferences/ru.lproj/GeneralPreferences.strings
@@ -32,8 +32,8 @@
 /* Class = "NSButton"; ibShadowedToolTip = "Notifications are only visible if Hearthstone is not focused"; ObjectID = "hzK-vu-1RX"; */
 "hzK-vu-1RX.ibShadowedToolTip" = "Notifications are only visible if Hearthstone is not focused";
 
-/* Class = "NSButtonCell"; title = "Enable Apphealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
-"mBv-nX-Cn3.title" = "Enable Apphealth icon badge";
+/* Class = "NSButtonCell"; title = "Enable AppHealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
+"mBv-nX-Cn3.title" = "Enable AppHealth icon badge";
 
 /* Class = "NSButtonCell"; title = "Close HSTracker when Hearthstone closes"; ObjectID = "oQm-3D-WOn"; */
 "oQm-3D-WOn.title" = "Close HSTracker when Hearthstone closes";

--- a/HSTracker/UIs/Preferences/th-TH.lproj/GamePreferences.strings
+++ b/HSTracker/UIs/Preferences/th-TH.lproj/GamePreferences.strings
@@ -5,8 +5,8 @@
 /* Class = "NSTextFieldCell"; title = "Hearthstone language"; ObjectID = "biS-yx-frk"; */
 "biS-yx-frk.title" = "Hearthstone language";
 
-/* Class = "NSButtonCell"; title = "Auto archive arena deck on run end"; ObjectID = "hMe-FU-CjR"; */
-"hMe-FU-CjR.title" = "Auto archive arena deck on run end";
+/* Class = "NSButtonCell"; title = "Auto archive Arena deck on run end"; ObjectID = "hMe-FU-CjR"; */
+"hMe-FU-CjR.title" = "Auto archive Arena deck on run end";
 
 /* Class = "NSButtonCell"; title = "Auto import and select decks"; ObjectID = "mhj-j8-OPU"; */
 "mhj-j8-OPU.title" = "Auto import and select decks";

--- a/HSTracker/UIs/Preferences/th-TH.lproj/GeneralPreferences.strings
+++ b/HSTracker/UIs/Preferences/th-TH.lproj/GeneralPreferences.strings
@@ -32,8 +32,8 @@
 /* Class = "NSButton"; ibShadowedToolTip = "Notifications are only visible if Hearthstone is not focused"; ObjectID = "hzK-vu-1RX"; */
 "hzK-vu-1RX.ibShadowedToolTip" = "Notifications are only visible if Hearthstone is not focused";
 
-/* Class = "NSButtonCell"; title = "Enable Apphealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
-"mBv-nX-Cn3.title" = "Enable Apphealth icon badge";
+/* Class = "NSButtonCell"; title = "Enable AppHealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
+"mBv-nX-Cn3.title" = "Enable AppHealth icon badge";
 
 /* Class = "NSButtonCell"; title = "Close HSTracker when Hearthstone closes"; ObjectID = "oQm-3D-WOn"; */
 "oQm-3D-WOn.title" = "Close HSTracker when Hearthstone closes";

--- a/HSTracker/UIs/Preferences/zh-Hans.lproj/BattlegroundsPreferences.strings
+++ b/HSTracker/UIs/Preferences/zh-Hans.lproj/BattlegroundsPreferences.strings
@@ -23,5 +23,5 @@
 /* Class = "NSButtonCell"; title = "Show tavern and triple history"; ObjectID = "nGc-Fs-IbI"; */
 "nGc-Fs-IbI.title" = "显示酒馆升级和三连历史";
 
-/* Class = "NSButtonCell"; title = "Show hero comparision"; ObjectID = "oXq-kH-uaV"; */
+/* Class = "NSButtonCell"; title = "Show hero comparison"; ObjectID = "oXq-kH-uaV"; */
 "oXq-kH-uaV.title" = "显示英雄对比";

--- a/HSTracker/UIs/Preferences/zh-Hans.lproj/GamePreferences.strings
+++ b/HSTracker/UIs/Preferences/zh-Hans.lproj/GamePreferences.strings
@@ -11,7 +11,7 @@
 /* Class = "NSTextFieldCell"; title = "Hearthstone language"; ObjectID = "biS-yx-frk"; */
 "biS-yx-frk.title" = "炉石传说语言";
 
-/* Class = "NSButtonCell"; title = "Auto archive arena deck on run end"; ObjectID = "hMe-FU-CjR"; */
+/* Class = "NSButtonCell"; title = "Auto archive Arena deck on run end"; ObjectID = "hMe-FU-CjR"; */
 "hMe-FU-CjR.title" = "在每轮结束时，自动存储竞技模式套牌";
 
 /* Class = "NSButtonCell"; title = "Auto import and select decks"; ObjectID = "mhj-j8-OPU"; */

--- a/HSTracker/UIs/Preferences/zh-Hans.lproj/GeneralPreferences.strings
+++ b/HSTracker/UIs/Preferences/zh-Hans.lproj/GeneralPreferences.strings
@@ -17,7 +17,7 @@
 /* Class = "NSButtonCell"; title = "Save replays"; ObjectID = "vod-AA-O2m"; */
 "vod-AA-O2m.title" = "保存回放";
 
-/* Class = "NSButtonCell"; title = "Enable Apphealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
+/* Class = "NSButtonCell"; title = "Enable AppHealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
 "mBv-nX-Cn3.title" = "使用炉石传说符号";
 
 /* Class = "NSButtonCell"; title = "Prefer golden cards when exporting to Hearthstone"; ObjectID = "1BI-nh-nxq"; */

--- a/HSTracker/UIs/Preferences/zh-Hant.lproj/GamePreferences.strings
+++ b/HSTracker/UIs/Preferences/zh-Hant.lproj/GamePreferences.strings
@@ -5,7 +5,7 @@
 /* Class = "NSTextFieldCell"; title = "Hearthstone language"; ObjectID = "biS-yx-frk"; */
 "biS-yx-frk.title" = "爐石戰記的語言";
 
-/* Class = "NSButtonCell"; title = "Auto archive arena deck on run end"; ObjectID = "hMe-FU-CjR"; */
+/* Class = "NSButtonCell"; title = "Auto archive Arena deck on run end"; ObjectID = "hMe-FU-CjR"; */
 "hMe-FU-CjR.title" = "在每輪結束時，自動儲存競技場套牌";
 
 /* Class = "NSButtonCell"; title = "Auto import and select decks"; ObjectID = "mhj-j8-OPU"; */

--- a/HSTracker/UIs/Preferences/zh-Hant.lproj/GeneralPreferences.strings
+++ b/HSTracker/UIs/Preferences/zh-Hant.lproj/GeneralPreferences.strings
@@ -32,8 +32,8 @@
 /* Class = "NSButton"; ibShadowedToolTip = "Notifications are only visible if Hearthstone is not focused"; ObjectID = "hzK-vu-1RX"; */
 "hzK-vu-1RX.ibShadowedToolTip" = "目前視窗不是爐石戰記時才會顯示通知";
 
-/* Class = "NSButtonCell"; title = "Enable Apphealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
-"mBv-nX-Cn3.title" = "Enable Apphealth icon badge";
+/* Class = "NSButtonCell"; title = "Enable AppHealth icon badge"; ObjectID = "mBv-nX-Cn3"; */
+"mBv-nX-Cn3.title" = "Enable AppHealth icon badge";
 
 /* Class = "NSButtonCell"; title = "Close HSTracker when Hearthstone closes"; ObjectID = "oQm-3D-WOn"; */
 "oQm-3D-WOn.title" = "關閉爐石戰記時，也結束HSTracker";


### PR DESCRIPTION
Unify every preference pane on one layout and clean up several structural inconsistencies in the Preferences area.

Layout (all 9 panes):
- Convert General, Game, Mercenaries and Battlegrounds from ad-hoc customView + manual constraints to a uniform vertical NSStackView root (20pt edge insets, 10pt row spacing, leading alignment), matching the tracker panes so every tab reads the same.
- Even out group-box interior padding to 10pt on all sides (was 20h/10v) and give the Importing boxes their missing horizontal margins.
- Right-align the Game language combos to match the Trackers rows.

Text:
- Fix typos: "comparision" -> "comparison" and "Apphealth" -> "AppHealth" (matching the AppHealth class).
- Remove the stray colons on the Importing Template/Preview/Adventure labels; colons were used nowhere else.
- Normalize label capitalization to sentence case, capitalizing only official Hearthstone keywords (Battlecry, Deathrattle) and proper nouns / mode names (Battlegrounds, Arena, Tavern Brawl, Tier7, Bob's Buddy, Mercenaries). Common game nouns (tavern, hero, quest, trinket, mulligan) stay lowercase; "Mulligan Guide" keeps caps as HSReplay's feature name.
- Apply the same-token fixes to the localized .strings (English fallback values and source comments); no translations were changed.

Structure:
- Fix MercenariesPreferences.xib, which lived in a duplicated HSTracker/UIs/Preferences/HSTracker/UIs/Preferences/... tree caused by a group-relative path bug in the project file.
- Move ImportingPreferences.xib into Base.lproj and make it a variant group so it is localizable like every other pane.
- Rename GamePrefences.swift -> GamePreferences.swift so the controller and xib filenames match.