### PR TITLE
fix: complete and normalize the French settings translations

### DIFF
--- a/HSTracker/HSReplay/mul.lproj/HSReplayPreferences.xcstrings
+++ b/HSTracker/HSReplay/mul.lproj/HSReplayPreferences.xcstrings
@@ -10,6 +10,12 @@
             "state" : "new",
             "value" : "Duels"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duels"
+          }
         }
       }
     },
@@ -22,6 +28,12 @@
             "state" : "new",
             "value" : "Subscription status"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Statut de l'abonnement"
+          }
         }
       }
     },
@@ -33,6 +45,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Mercenaries"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mercenaires"
           }
         }
       }
@@ -51,6 +69,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Login to HSReplay"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se connecter à HSReplay.net"
           }
         },
         "ja" : {
@@ -99,6 +123,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Show upload notification"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher la notification d'envoi"
           }
         },
         "ja" : {
@@ -176,7 +206,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Synchroniser les résultats des parties"
+            "value" : "Envoyer les replays automatiquement"
           }
         },
         "it" : {
@@ -235,90 +265,6 @@
         }
       }
     },
-    "alf-8N-P9t.title" : {
-      "comment" : "Class = \"NSTextFieldCell\"; title = \"Log in with your Battle.net credentials on HSReplay.net to claim your existing replays. This will open your web browser.\"; ObjectID = \"alf-8N-P9t\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Melde Dich mit deinen Battle.net Zugangsdaten auf HSReplay.net an, um bestehende Replays hinzuzufügen. Dieser Vorgang öffnet ein neues Browser-Fenster."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Log in with your Battle.net credentials on HSReplay.net to claim your existing replays. This will open your web browser."
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Log in with your Battle.net credentials on HSReplay.net to claim your existing replays. This will open your web browser."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connectez-vous avec votre compte Battle.net sur HSReplay.net pour réclamer vos replays. Ceci ouvrira une fenetre dans votre navigateur web."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Log in with your Battle.net credentials on HSReplay.net to claim your existing replays. This will open your web browser."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Log in with your Battle.net credentials on HSReplay.net to claim your existing replays. This will open your web browser."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Log in with your Battle.net credentials on HSReplay.net to claim your existing replays. This will open your web browser."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Log in with your Battle.net credentials on HSReplay.net to claim your existing replays. This will open your web browser."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Log in with your Battle.net credentials on HSReplay.net to claim your existing replays. This will open your web browser."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Log in with your Battle.net credentials on HSReplay.net to claim your existing replays. This will open your web browser."
-          }
-        },
-        "th-TH" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Log in with your Battle.net credentials on HSReplay.net to claim your existing replays. This will open your web browser."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "用战网帐号登录 HSReplay，以同步您记录的对战回放。这将打开浏览器。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在HSReplay.net中使用Battle.net的帳號來登入，以同步儲存的重播紀錄。點擊後將開啟網頁瀏覽器。"
-          }
-        }
-      }
-    },
     "dX9-1S-Y1M.title" : {
       "comment" : "Class = \"NSButtonCell\"; title = \"Spectator\"; ObjectID = \"dX9-1S-Y1M\";",
       "extractionState" : "extracted_with_value",
@@ -333,6 +279,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Spectator"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spectateur"
           }
         },
         "ja" : {
@@ -388,6 +340,12 @@
             "state" : "new",
             "value" : "X"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "X"
+          }
         }
       }
     },
@@ -405,6 +363,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ranked"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Classé"
           }
         },
         "ja" : {
@@ -451,132 +415,6 @@
         }
       }
     },
-    "Ikd-r0-oiT.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Reset Account\"; ObjectID = \"Ikd-r0-oiT\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset Account"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset Account"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset Account"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Réinitialiser le compte"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset Account"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset Account"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset Account"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset Account"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset Account"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset Account"
-          }
-        },
-        "th-TH" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset Account"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重設帳號"
-          }
-        }
-      }
-    },
-    "JsZ-J6-FKG.title" : {
-      "comment" : "Class = \"NSTextFieldCell\"; title = \"Label\"; ObjectID = \"JsZ-J6-FKG\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Label"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Label"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Label"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Label"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Label"
-          }
-        },
-        "th-TH" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Label"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "標籤"
-          }
-        }
-      }
-    },
     "KV0-Rl-jeI.title" : {
       "comment" : "Class = \"NSBox\"; title = \"My Account\"; ObjectID = \"KV0-Rl-jeI\";",
       "extractionState" : "extracted_with_value",
@@ -585,6 +423,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "My Account"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compte"
           }
         },
         "zh-Hans" : {
@@ -609,6 +453,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tavern Brawl"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bras de fer"
           }
         },
         "ja" : {
@@ -671,6 +521,12 @@
             "value" : "Friendly"
           }
         },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Amical"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -724,89 +580,11 @@
             "state" : "new",
             "value" : "Find out more"
           }
-        }
-      }
-    },
-    "PFc-eW-dQG.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Claim Account\"; ObjectID = \"PFc-eW-dQG\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mit HSReplay verbinden"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Claim Account"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Claim Account"
-          }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lier mon compte"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Claim Account"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Claim Account"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Claim Account"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Claim Account"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Claim Account"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Claim Account"
-          }
-        },
-        "th-TH" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Claim Account"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "连接帐户"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "連結帳號"
+            "value" : "En savoir plus"
           }
         }
       }
@@ -825,6 +603,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Upload game modes"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modes de jeu à envoyer"
           }
         },
         "ja" : {
@@ -874,83 +658,11 @@
             "state" : "new",
             "value" : "Thank you for supporting us!"
           }
-        }
-      }
-    },
-    "UbW-mX-Jca.title" : {
-      "comment" : "Class = \"NSBox\"; title = \"Title\"; ObjectID = \"UbW-mX-Jca\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "標題"
-          }
-        }
-      }
-    },
-    "VPW-70-gcw.title" : {
-      "comment" : "Class = \"NSBox\"; title = \"Replay Uploads\"; ObjectID = \"VPW-70-gcw\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "上传回放"
-          }
-        }
-      }
-    },
-    "Wij-ky-VUj.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Disconnect from HSReplay\"; ObjectID = \"Wij-ky-VUj\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disconnect from HSReplay"
-          }
         },
-        "ja" : {
+        "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Disconnect from HSReplay"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disconnect from HSReplay"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disconnect from HSReplay"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disconnect from HSReplay"
-          }
-        },
-        "th-TH" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disconnect from HSReplay"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "断开与 HSReplay 的连接"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消連結HSReplay的帳號"
+            "value" : "Merci de nous soutenir !"
           }
         }
       }
@@ -969,6 +681,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Arena"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arène"
           }
         },
         "ja" : {
@@ -1031,6 +749,12 @@
             "value" : "Adventure / Practice"
           }
         },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aventure / Entraînement"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1075,42 +799,6 @@
         }
       }
     },
-    "y6L-Kw-KFY.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Disconnect from HSReplay\"; ObjectID = \"y6L-Kw-KFY\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbingung mit HSReplay trennen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disconnect from HSReplay"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Déconnecter HSReplay"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disconnect from HSReplay"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disconnect from HSReplay"
-          }
-        }
-      }
-    },
     "zQQ-GF-3Lg.title" : {
       "comment" : "Class = \"NSTextFieldCell\"; title = \"Login to claim your replays and enable all HSReplay.net features.\"; ObjectID = \"zQQ-GF-3Lg\";",
       "extractionState" : "extracted_with_value",
@@ -1119,6 +807,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Login to claim your replays and enable all HSReplay.net features."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connectez-vous pour réclamer vos replays et activer toutes les fonctionnalités de HSReplay.net."
           }
         },
         "zh-Hans" : {
@@ -1138,6 +832,12 @@
             "state" : "new",
             "value" : "Battlegrounds"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Champs de bataille"
+          }
         }
       }
     },
@@ -1155,6 +855,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Casual"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Normal"
           }
         },
         "ja" : {

--- a/HSTracker/UIs/Preferences/mul.lproj/BattlegroundsPreferences.xcstrings
+++ b/HSTracker/UIs/Preferences/mul.lproj/BattlegroundsPreferences.xcstrings
@@ -11,6 +11,12 @@
             "value" : "Show tiers"
           }
         },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les niveaux"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -28,6 +34,12 @@
             "state" : "new",
             "value" : "Show minion types"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les types de serviteurs"
+          }
         }
       }
     },
@@ -38,6 +50,12 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
+            "value" : "Bob's Buddy"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "Bob's Buddy"
           }
         }
@@ -51,6 +69,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Show trinket picking stats"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les stats de choix des babioles"
           }
         }
       }
@@ -86,7 +110,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Show turn counter"
+            "value" : "Afficher le compteur de tours"
           }
         },
         "it" : {
@@ -154,6 +178,12 @@
             "state" : "new",
             "value" : "Banned"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bannis"
+          }
         }
       }
     },
@@ -165,6 +195,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Show Battlecry and Deathrattle on tiers"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les Cris de guerre et Râles d'agonie sur les niveaux"
           }
         }
       }
@@ -178,6 +214,12 @@
             "state" : "new",
             "value" : "Always show tavern tier 7"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toujours afficher le niveau 7 de taverne"
+          }
         }
       }
     },
@@ -189,6 +231,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable Tier7 overlay"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activer l'overlay Tier7"
           }
         }
       }
@@ -202,6 +250,12 @@
             "state" : "new",
             "value" : "Reset Session"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réinitialiser la session"
+          }
         }
       }
     },
@@ -214,6 +268,12 @@
             "state" : "new",
             "value" : "Show Battlegrounds hero picking stats"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les stats de choix des héros de Champs de bataille"
+          }
         }
       }
     },
@@ -225,6 +285,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Show latest games"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les dernières parties"
           }
         }
       }
@@ -260,7 +326,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Show Bob's Buddy"
+            "value" : "Afficher Bob's Buddy"
           }
         },
         "it" : {
@@ -329,6 +395,12 @@
             "value" : "Show opponent warband"
           }
         },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher la bande de l'adversaire"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -346,6 +418,12 @@
             "state" : "new",
             "value" : "Session Recap"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Résumé de session"
+          }
         }
       }
     },
@@ -356,6 +434,12 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
+            "value" : "Tier7"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "Tier7"
           }
         }
@@ -369,6 +453,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Start, Current"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Départ, actuel"
           }
         }
       }
@@ -404,7 +494,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Always show average damage"
+            "value" : "Toujours afficher les dégâts moyens"
           }
         },
         "it" : {
@@ -473,6 +563,12 @@
             "value" : "Show tavern and triple history"
           }
         },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher l'historique de taverne et des triples"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -489,6 +585,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Show hero comparison"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher la comparaison des héros"
           }
         },
         "zh-Hans" : {
@@ -508,6 +610,12 @@
             "state" : "new",
             "value" : "Show Battlegrounds quest picking stats"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les stats de choix des quêtes de Champs de bataille"
+          }
         }
       }
     },
@@ -520,6 +628,12 @@
             "state" : "new",
             "value" : "Show MMR"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher le MMR"
+          }
         }
       }
     },
@@ -531,6 +645,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Scaling"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échelle"
           }
         }
       }
@@ -566,7 +686,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Show Bob's Buddy during combat"
+            "value" : "Afficher Bob's Buddy pendant les combats"
           }
         },
         "it" : {
@@ -634,6 +754,12 @@
             "state" : "new",
             "value" : "Show tavern spells"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les sorts de taverne"
+          }
         }
       }
     },
@@ -645,6 +771,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Current, Change"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actuel, évolution"
           }
         }
       }
@@ -680,7 +812,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Show Bob's Buddy during shopping"
+            "value" : "Afficher Bob's Buddy pendant les achats"
           }
         },
         "it" : {
@@ -748,6 +880,12 @@
             "state" : "new",
             "value" : "Show comp stats (in session recap)"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les stats de compositions (dans le résumé de session)"
+          }
         }
       }
     },
@@ -759,6 +897,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "100%"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "100 %"
           }
         }
       }
@@ -772,6 +916,12 @@
             "state" : "new",
             "value" : "Available"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disponibles"
+          }
         }
       }
     },
@@ -784,6 +934,12 @@
             "state" : "new",
             "value" : "Show Tier7 menu overlay (MMR & stats)"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher l'overlay du menu Tier7 (MMR et stats)"
+          }
         }
       }
     },
@@ -795,6 +951,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Show session recap"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher le résumé de session"
           }
         }
       }

--- a/HSTracker/UIs/Preferences/mul.lproj/GamePreferences.xcstrings
+++ b/HSTracker/UIs/Preferences/mul.lproj/GamePreferences.xcstrings
@@ -1,42 +1,6 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "9aT-vn-YLp.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Choose\"; ObjectID = \"9aT-vn-YLp\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auswählen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleccionar"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choisir"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choose"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escolher"
-          }
-        }
-      }
-    },
     "biS-yx-frk.title" : {
       "comment" : "Class = \"NSTextFieldCell\"; title = \"Hearthstone language\"; ObjectID = \"biS-yx-frk\";",
       "extractionState" : "extracted_with_value",
@@ -68,7 +32,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Langue Hearthstone"
+            "value" : "Langue de Hearthstone"
           }
         },
         "it" : {
@@ -141,6 +105,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Auto archive Arena deck on run end"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Archiver automatiquement le deck d'Arène en fin de série"
           }
         },
         "ja" : {
@@ -308,7 +278,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Import et sélection auto des decks"
+            "value" : "Importer et sélectionner les decks automatiquement"
           }
         },
         "it" : {
@@ -398,7 +368,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Langue HSTracker"
+            "value" : "Langue de HSTracker"
           }
         },
         "it" : {
@@ -543,42 +513,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "爐石戰記的程式目錄"
-          }
-        }
-      }
-    },
-    "ZIv-Kx-0sm.title" : {
-      "comment" : "Class = \"NSTextFieldCell\"; title = \"Decks backup directory\"; ObjectID = \"ZIv-Kx-0sm\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deck Backup Verzeichnis"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Directorio de copia de seguridad de mazos"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Répertoire des decks"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Decks backup directory"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diretório de backup dos Decks"
           }
         }
       }

--- a/HSTracker/UIs/Preferences/mul.lproj/GeneralPreferences.xcstrings
+++ b/HSTracker/UIs/Preferences/mul.lproj/GeneralPreferences.xcstrings
@@ -91,90 +91,6 @@
         }
       }
     },
-    "4f5-xO-gik.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Add a note on end game\"; ObjectID = \"4f5-xO-gik\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Füge eine Bemerkung am Ende des Spiels hinzu."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add a note on end game"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add a note on end game"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajoute une note en fin de partie"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add a note on end game"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add a note on end game"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "게임이 끝나면 메모 추가하기"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add a note on end game"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adicionar uma nota ao final do jogo"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add a note on end game"
-          }
-        },
-        "th-TH" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add a note on end game"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "当对局结束时新增记录"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在比賽結束時新增筆記"
-          }
-        }
-      }
-    },
     "08B-rI-8LA.ibShadowedToolTip" : {
       "comment" : "Class = \"NSButton\"; ibShadowedToolTip = \"Notifications are only visible if Hearthstone is not focused\"; ObjectID = \"08B-rI-8LA\";",
       "extractionState" : "extracted_with_value",
@@ -206,7 +122,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les notifications sont seulement visibles si Hearthstone n'est pas visible"
+            "value" : "Les notifications sont visibles uniquement si Hearthstone n'est pas au premier plan"
           }
         },
         "it" : {
@@ -296,7 +212,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Me notifier quand la partie commence"
+            "value" : "Notifier au début de la partie"
           }
         },
         "it" : {
@@ -386,7 +302,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les notifications sont seulement visibles si Hearthstone n'est pas visible"
+            "value" : "Les notifications sont visibles uniquement si Hearthstone n'est pas au premier plan"
           }
         },
         "it" : {
@@ -476,7 +392,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Me notifier quand mon opposant concède"
+            "value" : "Notifier à la concession de l'adversaire"
           }
         },
         "it" : {
@@ -551,6 +467,12 @@
             "value" : "Notifications are only visible if Hearthstone is not focused"
           }
         },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les notifications sont visibles uniquement si Hearthstone n'est pas au premier plan"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -589,78 +511,6 @@
         }
       }
     },
-    "hzK-vu-1RX.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Close HSTracker when Hearthstone closes\"; ObjectID = \"hzK-vu-1RX\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beende HSTracker, wenn Hearthstone beendet wird"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Close HSTracker when Hearthstone closes"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fermer HSTracker quand on ferme Hearthstone"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Close HSTracker when Hearthstone closes"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fechar HSTracker quando Hearthstone fechar"
-          }
-        }
-      }
-    },
-    "lku-8T-sZE.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Save replays\"; ObjectID = \"lku-8T-sZE\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Replays speichern"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save replays"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enregistrer les replays"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save replays"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save replays"
-          }
-        }
-      }
-    },
     "mBv-nX-Cn3.title" : {
       "comment" : "Class = \"NSButtonCell\"; title = \"Enable AppHealth icon badge\"; ObjectID = \"mBv-nX-Cn3\";",
       "extractionState" : "extracted_with_value",
@@ -692,7 +542,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Activer le badge Santé de HSTracker"
+            "value" : "Activer le badge AppHealth sur l'icône"
           }
         },
         "it" : {
@@ -755,13 +605,37 @@
       "comment" : "Class = \"NSButtonCell\"; title = \"Close HSTracker when Hearthstone closes\"; ObjectID = \"oQm-3D-WOn\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beende HSTracker, wenn Hearthstone beendet wird"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close HSTracker when Hearthstone closes"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close HSTracker when Hearthstone closes"
+          }
+        },
         "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close HSTracker when Hearthstone closes"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fermer HSTracker à la fermeture de Hearthstone"
+          }
+        },
+        "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Close HSTracker when Hearthstone closes"
@@ -783,6 +657,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Close HSTracker when Hearthstone closes"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fechar HSTracker quando Hearthstone fechar"
           }
         },
         "ru" : {
@@ -842,7 +722,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Me notifier quand mon tour commence"
+            "value" : "Notifier au début du tour"
           }
         },
         "it" : {
@@ -901,71 +781,41 @@
         }
       }
     },
-    "TKd-w3-odf.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Use Arena Helper\"; ObjectID = \"TKd-w3-odf\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use Arena Helper"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use Arena Helper"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "투기장 헬퍼 사용"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use Arena Helper"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use Arena Helper"
-          }
-        },
-        "th-TH" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use Arena Helper"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "使用竞技模式助手"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "使用競技場小幫手"
-          }
-        }
-      }
-    },
     "vod-AA-O2m.title" : {
       "comment" : "Class = \"NSButtonCell\"; title = \"Save replays\"; ObjectID = \"vod-AA-O2m\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Replays speichern"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Save replays"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save replays"
+          }
+        },
         "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save replays"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enregistrer les replays"
+          }
+        },
+        "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Save replays"
@@ -984,6 +834,12 @@
           }
         },
         "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save replays"
+          }
+        },
+        "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Save replays"
@@ -1046,7 +902,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Utiliser les notifications Toast à la place du Notification Center"
+            "value" : "Utiliser les notifications Toast au lieu du Centre de notifications"
           }
         },
         "it" : {
@@ -1136,7 +992,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les notifications sont seulement visibles si Hearthstone n'est pas visible"
+            "value" : "Les notifications sont visibles uniquement si Hearthstone n'est pas au premier plan"
           }
         },
         "it" : {

--- a/HSTracker/UIs/Preferences/mul.lproj/ImportingPreferences.xcstrings
+++ b/HSTracker/UIs/Preferences/mul.lproj/ImportingPreferences.xcstrings
@@ -10,6 +10,12 @@
             "state" : "new",
             "value" : "Template"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modèle"
+          }
         }
       }
     },
@@ -21,6 +27,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Adventure"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aventure"
           }
         }
       }
@@ -34,6 +46,12 @@
             "state" : "new",
             "value" : "Template"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modèle"
+          }
         }
       }
     },
@@ -45,6 +63,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Include passive cards"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inclure les cartes passives"
           }
         }
       }
@@ -58,6 +82,12 @@
             "state" : "new",
             "value" : "Preview"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aperçu"
+          }
         }
       }
     },
@@ -70,6 +100,12 @@
             "state" : "new",
             "value" : "Arena"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arène"
+          }
         }
       }
     },
@@ -80,6 +116,12 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
+            "value" : "Duels"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "Duels"
           }
         }
@@ -94,6 +136,12 @@
             "state" : "new",
             "value" : "Template"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modèle"
+          }
         }
       }
     },
@@ -105,6 +153,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Dungeon"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Donjon"
           }
         }
       }
@@ -118,6 +172,12 @@
             "state" : "new",
             "value" : "Preview"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aperçu"
+          }
         }
       }
     },
@@ -129,6 +189,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Dungeon Run"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expédition en donjon"
           }
         }
       }
@@ -142,6 +208,12 @@
             "state" : "new",
             "value" : "Monster Hunt"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chasse aux monstres"
+          }
         }
       }
     },
@@ -153,6 +225,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Rumble Run"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Baston royale"
           }
         }
       }
@@ -166,6 +244,12 @@
             "state" : "new",
             "value" : "The Dalaran Heist"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le Casse de Dalaran"
+          }
         }
       }
     },
@@ -178,6 +262,12 @@
             "state" : "new",
             "value" : "Tombs of Terror"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les Tombes de la terreur"
+          }
         }
       }
     },
@@ -189,6 +279,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aperçu"
           }
         }
       }

--- a/HSTracker/UIs/Preferences/mul.lproj/MercenariesPreferences.xcstrings
+++ b/HSTracker/UIs/Preferences/mul.lproj/MercenariesPreferences.xcstrings
@@ -10,6 +10,12 @@
             "state" : "new",
             "value" : "Show ability icons below player Mercenaries"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les icônes de capacité sous les Mercenaires du joueur"
+          }
         }
       }
     },
@@ -21,6 +27,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Show opponent Mercenary abilities on hover"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les capacités des Mercenaires de l'adversaire au survol"
           }
         }
       }
@@ -34,6 +46,12 @@
             "state" : "new",
             "value" : "Show player Mercenary abilities on hover"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les capacités des Mercenaires du joueur au survol"
+          }
         }
       }
     },
@@ -46,6 +64,12 @@
             "state" : "new",
             "value" : "Show Tasks panel while in Mercenaries mode"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher le panneau des tâches en mode Mercenaires"
+          }
         }
       }
     },
@@ -57,6 +81,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Show ability icons above opponent Mercenaries"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les icônes de capacité au-dessus des Mercenaires de l'adversaire"
           }
         }
       }

--- a/HSTracker/UIs/Preferences/mul.lproj/OpponentTrackersPreferences.xcstrings
+++ b/HSTracker/UIs/Preferences/mul.lproj/OpponentTrackersPreferences.xcstrings
@@ -1,102 +1,6 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "0rm-Kh-0Ob.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Show Libram counter\"; ObjectID = \"0rm-Kh-0Ob\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示圣契计数器"
-          }
-        }
-      }
-    },
-    "9eg-6X-x7A.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Show Spell counter\"; ObjectID = \"9eg-6X-x7A\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zeige gegnerischen Spell-Counter"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Spell counter"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Spell counter"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voir le compteur de sorts"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Spell counter"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Spell counter"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "주문 갯수 보여주기"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Spell counter"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Spell counter"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Spell counter"
-          }
-        },
-        "th-TH" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Spell counter"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示法术计数器"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "顯示法術計算器"
-          }
-        }
-      }
-    },
     "50X-Tt-yJa.title" : {
       "comment" : "Class = \"NSButtonCell\"; title = \"Show opponent in-hand card huds\"; ObjectID = \"50X-Tt-yJa\";",
       "extractionState" : "extracted_with_value",
@@ -128,7 +32,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Voir les infos des cartes de l'adversaire"
+            "value" : "Afficher les infos des cartes en main de l'adversaire"
           }
         },
         "it" : {
@@ -218,7 +122,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Voir la chance de pioche de l'adversaire"
+            "value" : "Afficher les chances de pioche de l'adversaire"
           }
         },
         "it" : {
@@ -308,7 +212,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Voir la classe et le nom du joueur"
+            "value" : "Afficher la classe et le nom du joueur"
           }
         },
         "it" : {
@@ -398,7 +302,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Voir le compteur de Râles d'agonie"
+            "value" : "Afficher le compteur de Râles d'agonie"
           }
         },
         "it" : {
@@ -453,102 +357,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "顯示死亡之聲計算器"
-          }
-        }
-      }
-    },
-    "BFR-Pw-i1H.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Show Jade Counter\"; ObjectID = \"BFR-Pw-i1H\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zeige Jade-Counter"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Jade Counter"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Jade Counter"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voir le compteur Jade"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Jade Counter"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Jade Counter"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "비취 카운터 보여주기"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Jade Counter"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Jade Counter"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Jade Counter"
-          }
-        },
-        "th-TH" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Jade Counter"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示青玉魔像计数器"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "顯示翠玉魔像計算器"
-          }
-        }
-      }
-    },
-    "d7f-oO-njY.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Show Galakrond invoke counter\"; ObjectID = \"d7f-oO-njY\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示迦拉克隆计数器"
           }
         }
       }
@@ -674,7 +482,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Voir les dégâts sur table"
+            "value" : "Afficher les dégâts sur table"
           }
         },
         "it" : {
@@ -764,7 +572,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Voir le nombre de cartes de l'adversaire"
+            "value" : "Afficher le nombre de cartes de l'adversaire"
           }
         },
         "it" : {
@@ -832,6 +640,12 @@
             "state" : "new",
             "value" : "Show counters"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les compteurs"
+          }
         }
       }
     },
@@ -844,6 +658,12 @@
             "state" : "new",
             "value" : "Show active effects"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les effets actifs"
+          }
         }
       }
     },
@@ -855,6 +675,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Show maximum Health, Mana, and Hand Size"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les maximums de points de vie, de mana et de cartes en main"
           }
         }
       }
@@ -890,7 +716,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Voir le tracker de l'adversaire"
+            "value" : "Afficher le tracker de l'adversaire"
           }
         },
         "it" : {
@@ -963,6 +789,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cardlist opens on mouseover"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrir la liste des cartes au survol"
           }
         },
         "ja" : {
@@ -1040,7 +872,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Voir les cartes créées"
+            "value" : "Inclure les cartes créées"
           }
         },
         "it" : {
@@ -1108,6 +940,12 @@
             "state" : "new",
             "value" : "Show related cards tooltip"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher l'infobulle des cartes liées"
+          }
         }
       }
     },
@@ -1125,6 +963,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Prevent tracker from covering opponent's name"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Empêcher le tracker de masquer le nom de l'adversaire"
           }
         },
         "ja" : {
@@ -1171,90 +1015,6 @@
         }
       }
     },
-    "RyA-1i-LPY.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Show C'Thun counter\"; ObjectID = \"RyA-1i-LPY\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zeige gegnerischen C'Thun-Counter"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show C'Thun counter"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show C'Thun counter"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voir le compteur C'Thun"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show C'Thun counter"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show C'Thun counter"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "S크툰 카운터 보여주기"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show C'Thun counter"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show C'Thun counter"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show C'Thun counter"
-          }
-        },
-        "th-TH" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show C'Thun counter"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示克苏恩计数器"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "顯示克蘇恩計算器"
-          }
-        }
-      }
-    },
     "W6j-bY-6aE.title" : {
       "comment" : "Class = \"NSButtonCell\"; title = \"Show graveyard\"; ObjectID = \"W6j-bY-6aE\";",
       "extractionState" : "extracted_with_value",
@@ -1269,6 +1029,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Show graveyard"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher le cimetière"
           }
         },
         "ja" : {
@@ -1323,6 +1089,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable setting opponent deck in non-friendly matches"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autoriser la sélection du deck de l'adversaire hors parties amicales"
           }
         }
       }

--- a/HSTracker/UIs/Preferences/mul.lproj/PlayerTrackersPreferences.xcstrings
+++ b/HSTracker/UIs/Preferences/mul.lproj/PlayerTrackersPreferences.xcstrings
@@ -17,6 +17,12 @@
             "value" : "Cardlist opens on mouseover"
           }
         },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrir la liste des cartes au survol"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -65,13 +71,37 @@
       "comment" : "Class = \"NSButtonCell\"; title = \"Show graveyard\"; ObjectID = \"5Sm-dB-rVB\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeige Graveyard"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show graveyard"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show graveyard"
+          }
+        },
         "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show graveyard"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher le cimetière"
+          }
+        },
+        "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Show graveyard"
@@ -93,6 +123,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Show graveyard"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar cemitério"
           }
         },
         "ru" : {
@@ -152,7 +188,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Voir la chance de pioche du joueur"
+            "value" : "Afficher les chances de pioche du joueur"
           }
         },
         "it" : {
@@ -220,41 +256,11 @@
             "state" : "new",
             "value" : "Highlight synergies in the deck"
           }
-        }
-      }
-    },
-    "D65-CQ-243.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Show graveyard\"; ObjectID = \"D65-CQ-243\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zeige Graveyard"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show graveyard"
-          }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Voir le cimetière"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show graveyard"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar cemitério"
+            "value" : "Surligner les synergies dans le deck"
           }
         }
       }
@@ -290,7 +296,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Voir le nom du deck"
+            "value" : "Afficher le nom du deck"
           }
         },
         "it" : {
@@ -358,6 +364,12 @@
             "state" : "new",
             "value" : "E.T.C.'s Band"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Groupe d'E.T.C."
+          }
         }
       }
     },
@@ -369,6 +381,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Show counters"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les compteurs"
           }
         }
       }
@@ -404,7 +422,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Couleur carte en main"
+            "value" : "Couleur des cartes en main"
           }
         },
         "it" : {
@@ -494,7 +512,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Illumine les pioches de cartes"
+            "value" : "Faire clignoter à la pioche"
           }
         },
         "it" : {
@@ -563,22 +581,16 @@
             "value" : "Show top cards"
           }
         },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les cartes du dessus"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示牌库顶卡牌"
-          }
-        }
-      }
-    },
-    "hcz-Gp-orK.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Show Galakrond invoke counter\"; ObjectID = \"hcz-Gp-orK\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示迦拉克隆计数器"
           }
         }
       }
@@ -614,7 +626,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Voir le compteur de Râles d'agonie"
+            "value" : "Afficher le compteur de Râles d'agonie"
           }
         },
         "it" : {
@@ -682,6 +694,12 @@
             "state" : "new",
             "value" : "Show related cards tooltip"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher l'infobulle des cartes liées"
+          }
         }
       }
     },
@@ -695,178 +713,16 @@
             "value" : "Show bottom cards"
           }
         },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les cartes du dessous"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示牌库底卡牌"
-          }
-        }
-      }
-    },
-    "LGM-aC-rL6.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Show Spell counter\"; ObjectID = \"LGM-aC-rL6\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zeige Spell-Counter"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Spell counter"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Spell counter"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voir le compteur de sorts"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Spell counter"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Spell counter"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "주문 갯수 보여주기"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Spell counter"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar contador de Magias"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Spell counter"
-          }
-        },
-        "th-TH" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Spell counter"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示法术计数器"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "顯示法術計算器"
-          }
-        }
-      }
-    },
-    "MDW-Ea-Q6M.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Show Jade Counter\"; ObjectID = \"MDW-Ea-Q6M\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zeige Jade-Counter"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Jade Counter"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Jade Counter"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voir le compteur Jade"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Jade Counter"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Jade Counter"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "비취 카운터 보여주기"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Jade Counter"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Jade Counter"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Jade Counter"
-          }
-        },
-        "th-TH" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Jade Counter"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示青玉魔像计数器"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "顯示翠玉魔像計算器"
           }
         }
       }
@@ -902,7 +758,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Voir le tracker joueur"
+            "value" : "Afficher le tracker du joueur"
           }
         },
         "it" : {
@@ -961,54 +817,6 @@
         }
       }
     },
-    "o5X-sj-pxz.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Show Libram counter\"; ObjectID = \"o5X-sj-pxz\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示圣契计数器"
-          }
-        }
-      }
-    },
-    "oIi-8e-cCP.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Show win-loss ratio\"; ObjectID = \"oIi-8e-cCP\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zeige Sieg-Niederlage Verhältnis"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show win-loss ratio"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voir le ratio victoire-défaite"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show win-loss ratio"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar percentagem vitória-derrota"
-          }
-        }
-      }
-    },
     "r3h-Qd-YPW.title" : {
       "comment" : "Class = \"NSButtonCell\"; title = \"Include obtained cards\"; ObjectID = \"r3h-Qd-YPW\";",
       "extractionState" : "extracted_with_value",
@@ -1040,7 +848,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ajouter les cartes reçues"
+            "value" : "Inclure les cartes obtenues"
           }
         },
         "it" : {
@@ -1130,7 +938,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Voir les dégâts sur table"
+            "value" : "Afficher les dégâts sur table"
           }
         },
         "it" : {
@@ -1193,13 +1001,37 @@
       "comment" : "Class = \"NSButtonCell\"; title = \"Show win-loss ratio\"; ObjectID = \"Ro2-NC-xMD\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeige Sieg-Niederlage Verhältnis"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show win-loss ratio"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show win-loss ratio"
+          }
+        },
         "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show win-loss ratio"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher le ratio victoire-défaite"
+          }
+        },
+        "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Show win-loss ratio"
@@ -1221,6 +1053,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Show win-loss ratio"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar percentagem vitória-derrota"
           }
         },
         "ru" : {
@@ -1245,90 +1083,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "顯示勝率"
-          }
-        }
-      }
-    },
-    "Tex-bu-toa.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Show C'Thun counter\"; ObjectID = \"Tex-bu-toa\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zeige C'Thun-Counter"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show C'Thun counter"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show C'Thun counter"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voir le compteur C'Thun"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show C'Thun counter"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show C'Thun counter"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "크툰 카운터 보여주기"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show C'Thun counter"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar contador do C'Thun"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show C'Thun counter"
-          }
-        },
-        "th-TH" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show C'Thun counter"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示克苏恩计数器"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "顯示克蘇恩計算器"
           }
         }
       }
@@ -1364,7 +1118,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Voir le nombre de cartes du joueur"
+            "value" : "Afficher le nombre de cartes du joueur"
           }
         },
         "it" : {
@@ -1432,6 +1186,12 @@
             "state" : "new",
             "value" : "Show maximum Health, Mana, and Hand Size"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les maximums de points de vie, de mana et de cartes en main"
+          }
         }
       }
     },
@@ -1443,6 +1203,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Show active effects"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les effets actifs"
           }
         }
       }

--- a/HSTracker/UIs/Preferences/mul.lproj/TrackersPreferences.xcstrings
+++ b/HSTracker/UIs/Preferences/mul.lproj/TrackersPreferences.xcstrings
@@ -11,6 +11,12 @@
             "value" : "Show experience counter"
           }
         },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher le compteur d'expérience"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -50,7 +56,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Positionnement automatique des trackers"
+            "value" : "Positionner les trackers automatiquement"
           }
         },
         "it" : {
@@ -140,7 +146,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Autorise HSTracker à fonctionner en plein écran"
+            "value" : "Autoriser HSTracker à fonctionner en plein écran"
           }
         },
         "it" : {
@@ -215,6 +221,12 @@
             "value" : "Disable tracking in spectator mode"
           }
         },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désactiver le suivi en mode spectateur"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -259,90 +271,6 @@
         }
       }
     },
-    "36t-98-K9E.title" : {
-      "comment" : "Class = \"NSTextFieldCell\"; title = \"Floating card style\"; ObjectID = \"36t-98-K9E\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mouseover Kartenstil"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Floating card style"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Floating card style"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Style des tooltips"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Floating card style"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Floating card style"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Floating card style"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Floating card style"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Floating card style"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Floating card style"
-          }
-        },
-        "th-TH" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Floating card style"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "卡牌样式设为漂浮"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "卡片的懸浮風格"
-          }
-        }
-      }
-    },
     "aO1-IW-r7y.ibShadowedToolTip" : {
       "comment" : "Class = \"NSButton\"; ibShadowedToolTip = \"HSTracker will be visible on all your workspace while playing\"; ObjectID = \"aO1-IW-r7y\";",
       "extractionState" : "extracted_with_value",
@@ -374,7 +302,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "HSTracker sera visible sur tous vos workspace pendant que vous jouez"
+            "value" : "HSTracker reste visible sur tous les espaces de travail pendant les parties"
           }
         },
         "it" : {
@@ -886,6 +814,12 @@
             "state" : "new",
             "value" : "Enable Mulligan Guide"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activer le Mulligan Guide"
+          }
         }
       }
     },
@@ -1259,232 +1193,16 @@
             "value" : "Show flavor text"
           }
         },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher le texte d'ambiance"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示风味文字"
-          }
-        }
-      }
-    },
-    "fhr-Mz-lcf.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Show topdeck chance\"; ObjectID = \"fhr-Mz-lcf\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show topdeck chance"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show topdeck chance"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "탑덱 찬스 보여주기"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show topdeck chance"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show topdeck chance"
-          }
-        },
-        "th-TH" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show topdeck chance"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示抽卡机会"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "顯示抽牌機率"
-          }
-        }
-      }
-    },
-    "GY2-Lg-KWo.ibShadowedObjectValues[0]" : {
-      "comment" : "Class = \"NSComboBoxCell\"; GY2-Lg-KWo.ibShadowedObjectValues[0] = \"Text\"; ObjectID = \"GY2-Lg-KWo\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Text"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Text"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Text"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Texte"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Text"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Text"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "글자"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Text"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Text"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Text"
-          }
-        },
-        "th-TH" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Text"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "文字"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "文字"
-          }
-        }
-      }
-    },
-    "GY2-Lg-KWo.ibShadowedObjectValues[1]" : {
-      "comment" : "Class = \"NSComboBoxCell\"; GY2-Lg-KWo.ibShadowedObjectValues[1] = \"Image\"; ObjectID = \"GY2-Lg-KWo\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bild"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Image"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Image"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Image"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Image"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Image"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이미지"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Image"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Image"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Image"
-          }
-        },
-        "th-TH" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Image"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "图片"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "圖片"
           }
         }
       }
@@ -1520,7 +1238,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Voir les couleurs de rareté"
+            "value" : "Afficher les couleurs de rareté"
           }
         },
         "it" : {
@@ -1589,6 +1307,12 @@
             "value" : "Show constructed mulligan"
           }
         },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher le mulligan en mode Construit"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1611,6 +1335,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hide all trackers when game is in background"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masquer tous les trackers quand le jeu est en arrière-plan"
           }
         },
         "ja" : {
@@ -1778,7 +1508,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cacher tous les trackers quand aucune partie n'est lancée"
+            "value" : "Masquer tous les trackers quand aucune partie n'est lancée"
           }
         },
         "it" : {
@@ -1868,7 +1598,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Voir les cartes au survol des trackers"
+            "value" : "Afficher les cartes au survol des trackers"
           }
         },
         "it" : {
@@ -1923,42 +1653,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "滑鼠停留在記牌器時顯示卡牌"
-          }
-        }
-      }
-    },
-    "Jj4-X9-UWO.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Show topdeck chance\"; ObjectID = \"Jj4-X9-UWO\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zeige Topdeck-Wahrscheinlichkeit"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show topdeck chance"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voir les chances de topdeck"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show topdeck chance"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show topdeck chance"
           }
         }
       }
@@ -2049,36 +1743,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "主題"
-          }
-        }
-      }
-    },
-    "ndN-hu-6Rx.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Include obtained cards\"; ObjectID = \"ndN-hu-6Rx\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entdeckte und fremde Karten mit einbeziehen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Incluir las cartas obtenidas"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Include obtained cards"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Incluir cards obtidos"
           }
         }
       }
@@ -2182,6 +1846,12 @@
             "state" : "new",
             "value" : "Show availability on deck selection screen"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher la disponibilité sur l'écran de sélection des decks"
+          }
         }
       }
     },
@@ -2283,6 +1953,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Show mulligan overlay at start of game"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher l'overlay de mulligan en début de partie"
           }
         }
       }
@@ -2408,7 +2084,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Voir le chronomètre"
+            "value" : "Afficher le chronomètre"
           }
         },
         "it" : {
@@ -2498,7 +2174,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Surligner les cartes perdues"
+            "value" : "Surligner les cartes défaussées du deck"
           }
         },
         "it" : {
@@ -2588,7 +2264,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Voir l'aide aux secrets"
+            "value" : "Afficher l'aide aux secrets"
           }
         },
         "it" : {

--- a/Translations/macOS/Localizable.xcstrings
+++ b/Translations/macOS/Localizable.xcstrings
@@ -1800,9 +1800,16 @@
       }
     },
     "Battlegrounds" : {
+      "comment" : "Settings toolbar tab title. Kept untranslated: \"Champs de bataille\" overflows the 600pt toolbar.",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Battlegrounds"
+          }
+        },
+        "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Battlegrounds"
@@ -2641,6 +2648,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "By clicking 'Reset' you will clear your list of Latest Games and make your Start MMR the same as your current MMR."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En cliquant sur « Réinitialiser », vous effacerez votre liste des dernières parties et votre MMR de départ sera aligné sur votre MMR actuel."
           }
         },
         "ko" : {
@@ -8001,6 +8014,23 @@
         }
       }
     },
+    "Importing" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importing"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Import"
+          }
+        }
+      }
+    },
     "In top 2:" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -8995,6 +9025,12 @@
             "state" : "translated",
             "value" : "Logged in to HSReplay.net as %@. Open your collection and it will be automatically uploaded."
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connecté à HSReplay.net en tant que %@. Ouvrez votre collection et elle sera envoyée automatiquement."
+          }
         }
       }
     },
@@ -9005,6 +9041,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Logged in to HSReplay.net. Open your collection and it will be automatically uploaded."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connecté à HSReplay.net. Ouvrez votre collection et elle sera envoyée automatiquement."
           }
         }
       }
@@ -9106,6 +9148,12 @@
             "state" : "translated",
             "value" : "Login to claim your replays and enable all HSReplay.net features."
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connectez-vous pour réclamer vos replays et activer toutes les fonctionnalités de HSReplay.net."
+          }
         }
       }
     },
@@ -9116,6 +9164,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Login to HSReplay.net"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se connecter à HSReplay.net"
           }
         }
       }
@@ -9573,6 +9627,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mercenaries"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mercenaires"
           }
         },
         "ko" : {
@@ -11220,6 +11280,23 @@
         }
       }
     },
+    "Opponent" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opponent"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adversaire"
+          }
+        }
+      }
+    },
     "Opponent tracker" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -11317,6 +11394,12 @@
             "state" : "translated",
             "value" : "Subscribed to HSReplay.net"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abonné à HSReplay.net"
+          }
         }
       }
     },
@@ -11327,6 +11410,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Subscribed to HSReplay.net"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abonné à HSReplay.net"
           }
         }
       }
@@ -11339,6 +11428,12 @@
             "state" : "translated",
             "value" : "Subscribed to Premium"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abonné à Premium"
+          }
         }
       }
     },
@@ -11349,6 +11444,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Subscribed to Tier7"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abonné à Tier7"
           }
         }
       }
@@ -11548,6 +11649,23 @@
         }
       }
     },
+    "Player" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Player"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Joueur"
+          }
+        }
+      }
+    },
     "Player tracker" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -11678,7 +11796,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Veuillez sélectionner votre application Hearthstone"
+            "value" : "Sélectionner l'application Hearthstone"
           }
         },
         "it" : {
@@ -12430,7 +12548,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reset"
+            "value" : "Réinitialiser"
           }
         },
         "it" : {
@@ -12496,6 +12614,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Resetting current Session"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réinitialiser la session actuelle"
           }
         },
         "ko" : {


### PR DESCRIPTION
The migration left the nine panes at 37% French, and some rows reverted to English because #1425 rebuilt the xibs and the translations stayed on the old object IDs.

- Bring the panes to 100%, moving stranded translations onto the live keys and fixing a few mistranslations.
- Translate the runtime strings, and add the Player, Opponent and Importing tab titles, which were missing from the catalog.
- Fix the HSReplay subscription status showing a raw key: it had no French, and localizedString falls back to Base.lproj, which no longer holds a Localizable.strings.
- Unify the wording: infinitives, Afficher/Masquer, no pronouns in labels.
- Drop 32 keys the xibs no longer contain.

The Battlegrounds tab keeps its English name, "Champs de bataille" would overflow the toolbar. The pane bodies still use it.