### PR TITLE
Add Simplified Chinese Battlegrounds preferences

### DIFF
--- a/HSTracker/UIs/Preferences/mul.lproj/BattlegroundsPreferences.xcstrings
+++ b/HSTracker/UIs/Preferences/mul.lproj/BattlegroundsPreferences.xcstrings
@@ -52,6 +52,12 @@
             "state" : "translated",
             "value" : "Afficher les types de serviteurs"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示随从类型"
+          }
         }
       }
     },
@@ -70,6 +76,12 @@
             "state" : "translated",
             "value" : "Bob's Buddy"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鲍勃之友"
+          }
         }
       }
     },
@@ -87,6 +99,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Afficher les stats de choix des babioles"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示饰品选择统计"
           }
         }
       }
@@ -135,6 +153,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Show minions and guides browser in pre-lobby"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在大厅中显示随从和指南浏览器"
           }
         }
       }
@@ -244,6 +268,12 @@
             "state" : "translated",
             "value" : "Bannis"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "禁用"
+          }
         }
       }
     },
@@ -261,6 +291,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Afficher les Cris de guerre et Râles d'agonie sur les niveaux"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在等级列表中显示战吼和亡语"
           }
         }
       }
@@ -280,6 +316,12 @@
             "state" : "translated",
             "value" : "Toujours afficher le niveau 7 de taverne"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "始终显示酒馆等级 7"
+          }
         }
       }
     },
@@ -297,6 +339,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Activer l'overlay Tier7"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用Tier7内嵌"
           }
         }
       }
@@ -316,6 +364,12 @@
             "state" : "translated",
             "value" : "Réinitialiser la session"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重置时段数据"
+          }
         }
       }
     },
@@ -334,6 +388,12 @@
             "state" : "translated",
             "value" : "Afficher les stats de choix des héros de Champs de bataille"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示战棋英雄选择统计"
+          }
         }
       }
     },
@@ -351,6 +411,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Afficher les dernières parties"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示最近对局"
           }
         }
       }
@@ -484,6 +550,12 @@
             "state" : "translated",
             "value" : "Résumé de session"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "时段回顾"
+          }
         }
       }
     },
@@ -498,6 +570,12 @@
           }
         },
         "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tier7"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tier7"
@@ -519,6 +597,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Départ, actuel"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "初始、当前"
           }
         }
       }
@@ -676,6 +760,12 @@
             "state" : "translated",
             "value" : "Afficher les stats de choix des quêtes de Champs de bataille"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示战棋任务选择统计"
+          }
         }
       }
     },
@@ -694,6 +784,12 @@
             "state" : "translated",
             "value" : "Afficher le MMR"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示 MMR"
+          }
         }
       }
     },
@@ -711,6 +807,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Échelle"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缩放比例"
           }
         }
       }
@@ -820,6 +922,12 @@
             "state" : "translated",
             "value" : "Afficher les sorts de taverne"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示酒馆法术"
+          }
         }
       }
     },
@@ -837,6 +945,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Actuel, évolution"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当前、变化"
           }
         }
       }
@@ -946,6 +1060,12 @@
             "state" : "translated",
             "value" : "Afficher les stats de compositions (dans le résumé de session)"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示阵容统计（在时段回顾中）"
+          }
         }
       }
     },
@@ -963,6 +1083,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "100 %"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "100%"
           }
         }
       }
@@ -1060,6 +1186,12 @@
             "state" : "translated",
             "value" : "Disponibles"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可用"
+          }
         }
       }
     },
@@ -1078,6 +1210,12 @@
             "state" : "translated",
             "value" : "Afficher l'overlay du menu Tier7 (MMR et stats)"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在菜单中显示 Tier7（等级积分和统计）"
+          }
         }
       }
     },
@@ -1095,6 +1233,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Afficher le résumé de session"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示时段回顾"
           }
         }
       }


### PR DESCRIPTION
## Summary

- add Simplified Chinese translations for all 24 previously untranslated entries in the Battlegrounds preferences catalog
- use the existing HDT translations for the Tier7 overlay, reset-session, session-recap, Bob’s Buddy, and scaling labels where applicable
- eliminate English fallback for Simplified Chinese users on this preferences page

## Validation

- validated the string catalog as JSON with jq
- compiled the catalog for zh-Hans with xcstringstool
- confirmed all 37 English entries now have zh-Hans localizations
- confirmed the compiled output contains the Tier7 checkbox and pre-lobby translations