### PR TITLE
Enable stats against opponent class 

### DIFF
--- a/HSTracker/Core/Settings.swift
+++ b/HSTracker/Core/Settings.swift
@@ -447,6 +447,8 @@ final class Settings {
     static var clearTrackersOnGameEnd: Bool
     @UserDefault(key: Settings.show_opponent_tracker, defaultValue: true)
     static var showOpponentTracker: Bool
+    @UserDefault(key: Settings.show_win_rate_against, defaultValue: false)
+    static var showWinRateAgainst: Bool
     @UserDefault(key: Settings.show_timer, defaultValue: false)
     static var showTimer: Bool
     @UserDefault(key: Settings.interacted_with_link_opponentDeck, defaultValue: false)
@@ -758,6 +760,7 @@ extension Settings {
     static let show_player_tracker = "show_player_tracker"
     static let clear_trackers_end = "clear_trackers_end"
     static let show_opponent_tracker = "show_opponent_tracker"
+    static let show_win_rate_against = "show_win_rate_against"
     static let show_timer = "show_timer"
 
     static let timer_hud_frame = "timer_hud_frame"

--- a/HSTracker/Logging/Game.swift
+++ b/HSTracker/Logging/Game.swift
@@ -294,6 +294,25 @@ class Game: NSObject, PowerEventHandler {
                 
                 tracker.graveyard = self.opponent.graveyard
                 tracker.playerClassId = self.opponent.playerClassId
+
+                tracker.recordTrackerMessage = ""
+                if Settings.showWinRateAgainst,
+                   let currentDeck = self.currentDeck,
+                   let opponentClass = self.opponent.originalClass,
+                   Cards.classes.contains(opponentClass),
+                   let deck = RealmHelper.getDeck(with: currentDeck.id) {
+                    let record = StatsHelper.getDeckRecord(deck: deck,
+                                                           againstClass: opponentClass,
+                                                           mode: .all)
+                    let total = record.wins + record.losses
+                    let percent = total > 0
+                        ? String(Int(round(Double(record.wins) * 100.0 / Double(total))))
+                        : "-"
+                    let className = String.localizedString(opponentClass.rawValue,
+                                                           comment: "").capitalized
+                    tracker.recordTrackerMessage = "VS \(className): "
+                        + "\(record.wins)-\(record.losses) (\(percent)%)"
+                }
                 
                 tracker.currentFormat = self.currentFormat
                 tracker.currentGameMode = self.currentGameMode
@@ -1572,7 +1591,7 @@ class Game: NSObject, PowerEventHandler {
 		                                   Settings.opponent_deathrattle_frame,
 		                                   Settings.show_opponent_class, Settings.opponent_graveyard_frame,
 		                                   Settings.opponent_graveyard_details_frame,
-                                           Settings.opponent_related_cards]
+                                           Settings.opponent_related_cards, Settings.show_win_rate_against]
 		
 		// events that should update all trackers
 		let allTrackerUpdateEvents = [Settings.rarity_colors, Events.reload_decks, Settings.window_locked, Settings.auto_position_trackers,

--- a/HSTracker/UIs/Preferences/Base.lproj/OpponentTrackersPreferences.xib
+++ b/HSTracker/UIs/Preferences/Base.lproj/OpponentTrackersPreferences.xib
@@ -26,21 +26,32 @@
                 <outlet property="showPlayerClass" destination="AOs-wd-f13" id="vyY-xh-9tG"/>
                 <outlet property="showPlayerMaxResources" destination="dFP-v4-7Gs" id="iLG-h7-6x2"/>
                 <outlet property="showPlayerRelatedCards" destination="5ic-Gb-JtT" id="Dp7-9b-TWr"/>
+                <outlet property="showWinRateAgainst" destination="WRa-teA-gst" id="WRa-teO-utl"/>
                 <outlet property="view" destination="DPe-et-cJR" id="cJe-z5-DVd"/>
             </connections>
         </customObject>
         <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="10" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" id="DPe-et-cJR">
-            <rect key="frame" x="0.0" y="0.0" width="432" height="428"/>
+            <rect key="frame" x="0.0" y="0.0" width="432" height="454"/>
             <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
             <subviews>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bt4-kn-GjS">
-                    <rect key="frame" x="20" y="402" width="392" height="16"/>
+                    <rect key="frame" x="20" y="428" width="392" height="16"/>
                     <buttonCell key="cell" type="check" title="Show opponent tracker" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="MLJ-7t-LVJ">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                     <connections>
                         <action selector="checkboxClicked:" target="-2" id="ktr-VS-gDn"/>
+                    </connections>
+                </button>
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WRa-teA-gst">
+                    <rect key="frame" x="20" y="402" width="392" height="16"/>
+                    <buttonCell key="cell" type="check" title="Win rate" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="WRa-teC-ell">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="checkboxClicked:" target="-2" id="WRa-teA-ctn"/>
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Vp4-QG-lNm">
@@ -240,6 +251,8 @@
                 <constraint firstAttribute="trailing" secondItem="mB7-0k-NWy" secondAttribute="trailing" constant="20" symbolic="YES" id="4o9-TG-JVw"/>
                 <constraint firstAttribute="trailing" secondItem="Vgg-OU-9bx" secondAttribute="trailing" constant="20" symbolic="YES" id="7V0-bj-IhT"/>
                 <constraint firstItem="wnH-Tv-Haz" firstAttribute="leading" secondItem="DPe-et-cJR" secondAttribute="leading" constant="20" symbolic="YES" id="8HV-1A-ja4"/>
+                <constraint firstItem="WRa-teA-gst" firstAttribute="leading" secondItem="DPe-et-cJR" secondAttribute="leading" constant="20" symbolic="YES" id="WRa-teL-ead"/>
+                <constraint firstAttribute="trailing" secondItem="WRa-teA-gst" secondAttribute="trailing" constant="20" symbolic="YES" id="WRa-teT-rai"/>
                 <constraint firstAttribute="trailing" secondItem="0w1-8P-7Ul" secondAttribute="trailing" constant="20" symbolic="YES" id="8cz-2a-o4B"/>
                 <constraint firstAttribute="trailing" secondItem="npw-Sr-U97" secondAttribute="trailing" constant="20" symbolic="YES" id="9Nd-Pi-1ua"/>
                 <constraint firstItem="S1f-xh-msr" firstAttribute="leading" secondItem="DPe-et-cJR" secondAttribute="leading" constant="20" symbolic="YES" id="A4q-Mk-WZr"/>

--- a/HSTracker/UIs/Preferences/OpponentTrackersPreferences.swift
+++ b/HSTracker/UIs/Preferences/OpponentTrackersPreferences.swift
@@ -17,6 +17,7 @@ class OpponentTrackersPreferences: PreferencePaneController, PreferencePane {
     var toolbarItemIcon = NSImage(named: "settings-opponent")!
 
     @IBOutlet var showOpponentTracker: NSButton!
+    @IBOutlet var showWinRateAgainst: NSButton!
     @IBOutlet var showCardHuds: NSButton!
     @IBOutlet var clearTrackersOnGameEnd: NSButton!
     @IBOutlet var showOpponentCardCount: NSButton!
@@ -43,6 +44,7 @@ class OpponentTrackersPreferences: PreferencePaneController, PreferencePane {
         }
         
         showOpponentTracker.state = Settings.showOpponentTracker ? .on : .off
+        showWinRateAgainst.state = Settings.showWinRateAgainst ? .on : .off
         showCardHuds.state = Settings.showCardHuds ? .on : .off
         clearTrackersOnGameEnd.state = Settings.clearTrackersOnGameEnd ? .on : .off
         showOpponentCardCount.state = Settings.showOpponentCardCount ? .on : .off
@@ -66,6 +68,8 @@ class OpponentTrackersPreferences: PreferencePaneController, PreferencePane {
     @IBAction func checkboxClicked(_ sender: NSButton) {
         if sender == showOpponentTracker {
             Settings.showOpponentTracker = showOpponentTracker.state == .on
+        } else if sender == showWinRateAgainst {
+            Settings.showWinRateAgainst = showWinRateAgainst.state == .on
         } else if sender == showCardHuds {
             Settings.showCardHuds = showCardHuds.state == .on
         } else if sender == clearTrackersOnGameEnd {

--- a/HSTracker/UIs/Preferences/mul.lproj/OpponentTrackersPreferences.xcstrings
+++ b/HSTracker/UIs/Preferences/mul.lproj/OpponentTrackersPreferences.xcstrings
@@ -1093,6 +1093,18 @@
         }
       }
     },
+    "WRa-teC-ell.title" : {
+      "comment" : "Class = \"NSButtonCell\"; title = \"Win rate\"; ObjectID = \"WRa-teC-ell\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Win rate"
+          }
+        }
+      }
+    },
     "ZkO-13-FoB.title" : {
       "comment" : "Class = \"NSButtonCell\"; title = \"Enable setting opponent deck in non-friendly matches\"; ObjectID = \"ZkO-13-FoB\";",
       "extractionState" : "extracted_with_value",

--- a/HSTracker/UIs/Trackers/StringTracker.swift
+++ b/HSTracker/UIs/Trackers/StringTracker.swift
@@ -13,11 +13,18 @@ class StringTracker: TextFrame {
     private let textRect = NSRect(x: 10, y: 1, width: CGFloat(kFrameWidth) - 20, height: 25)
 
     var message: String = ""
+    var fontSize: CGFloat = 18
+    var showsBackground = true
+    var verticallyCentersText = false
+    var verticalTextOffset: CGFloat = 0
 
     override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
 
-        add(image: "text-frame.png", rect: frameRect)
-        add(string: message, rect: textRect, alignment: .center)
+        if showsBackground {
+            add(image: "text-frame.png", rect: frameRect)
+        }
+        add(string: message, rect: textRect, alignment: .center, fontSize: fontSize,
+            verticallyCentered: verticallyCentersText, verticalOffset: verticalTextOffset)
     }
 }

--- a/HSTracker/UIs/Trackers/Tracker.swift
+++ b/HSTracker/UIs/Trackers/Tracker.swift
@@ -79,6 +79,10 @@ class Tracker: OverWindowController, CardCellHover {
         setOpacity()
         
         if playerType == .opponent {
+            recordTracker.fontSize = 15
+            recordTracker.showsBackground = false
+            recordTracker.verticallyCentersText = true
+            recordTracker.verticalTextOffset = -1
             window?.contentView?.addTrackingArea(getTrackingArea())
         }
     }
@@ -145,7 +149,7 @@ class Tracker: OverWindowController, CardCellHover {
             opponentDrawChance.isHidden = !Settings.showOpponentDrawChance
             playerDrawChance.isHidden = true
             playerClass.isHidden = !Settings.showOpponentClassInTracker
-            recordTracker.isHidden = true
+            recordTracker.isHidden = !Settings.showWinRateAgainst || recordTrackerMessage.isEmpty
         } else {
             cardCounter.isHidden = !Settings.showPlayerCardCount
             opponentDrawChance.isHidden = true
@@ -190,6 +194,7 @@ class Tracker: OverWindowController, CardCellHover {
         
         let bigFrameHeight = round(71 / ratio)
         let smallFrameHeight = round(40 / ratio)
+        let winRateFrameHeight = round(25 / ratio)
         
         var offsetFrames: CGFloat = 0
         var startHeight: CGFloat = 0
@@ -265,7 +270,7 @@ class Tracker: OverWindowController, CardCellHover {
             offsetFrames += smallFrameHeight
         }
         if !recordTracker.isHidden {
-            offsetFrames += smallFrameHeight
+            offsetFrames += playerType == .opponent ? winRateFrameHeight : smallFrameHeight
         }
 
         var totalCards = cardsView.count
@@ -301,6 +306,14 @@ class Tracker: OverWindowController, CardCellHover {
         
         let cardViewHeight = CGFloat(cardsView.count) * cardHeight
         var y: CGFloat = windowHeight - startHeight
+
+        if !recordTracker.isHidden && playerType == .opponent {
+            y -= winRateFrameHeight
+            recordTracker.frame = NSRect(x: 0,
+                                         y: y,
+                                         width: windowWidth,
+                                         height: winRateFrameHeight)
+        }
 
         if playerTop.count > 0 && Settings.showPlayerCardsTop {
             let playerTopHeight = CGFloat(playerTop.count) * cardHeight + smallFrameHeight + 5
@@ -387,7 +400,7 @@ class Tracker: OverWindowController, CardCellHover {
             graveyardCounter?.cardHeight = cardHeight
             graveyardCounter?.needsDisplay = true
         }
-        if !recordTracker.isHidden {
+        if !recordTracker.isHidden && playerType != .opponent {
             y -= smallFrameHeight
             recordTracker.frame = NSRect(x: 0,
                                          y: y,

--- a/HSTracker/UIs/Trackers/TrackerFrame.swift
+++ b/HSTracker/UIs/Trackers/TrackerFrame.swift
@@ -76,15 +76,23 @@ class TextFrame: NSView {
         add(string: String(format: format, val), rect: rect)
     }
 
-    func add(string val: String, rect: NSRect, alignment: NSTextAlignment = .left) {
+    func add(string val: String, rect: NSRect, alignment: NSTextAlignment = .left,
+             fontSize: CGFloat = 18, verticallyCentered: Bool = false,
+             verticalOffset: CGFloat = 0) {
         let attributes = TextAttributes()
-            .font(NSFont(name: "ChunkFive", size: round(18 / ratioHeight)))
+            .font(NSFont(name: "ChunkFive", size: round(fontSize / ratioHeight)))
             .foregroundColor(.white)
             .strokeColor(.black)
             .strokeWidth(-2)
             .alignment(alignment)
 
-        NSAttributedString(string: val, attributes: attributes)
-            .draw(in: ratio(rect))
+        let attributedString = NSAttributedString(string: val, attributes: attributes)
+        var drawRect = ratio(rect)
+        if verticallyCentered {
+            let textHeight = attributedString.size().height
+            drawRect.origin.y = bounds.midY - textHeight / 2 + verticalOffset / ratioHeight
+            drawRect.size.height = textHeight
+        }
+        attributedString.draw(in: drawRect)
     }
 }


### PR DESCRIPTION
Closes https://github.com/HearthSim/HSTracker/issues/1336

Added displaying of the win rate against opponent class, which was missing on MacOS client
<img width="150" height="300" alt="Screenshot 2026-09-10 at 11 34 24 AM" src="https://github.com/user-attachments/assets/b9eb98ea-50d6-4a13-8668-05a31a767c3f" />

<img width="400" height="150" alt="Screenshot 2026-09-10 at 11 35 44 AM" src="https://github.com/user-attachments/assets/7f00b43d-ea0b-46b3-b92c-7a960225096b" />
